### PR TITLE
feat(data): real secondary structure dataset loader (Issue #4)

### DIFF
--- a/scripts/train_baseline.py
+++ b/scripts/train_baseline.py
@@ -1,15 +1,27 @@
 """
 Baseline training script for secondary structure prediction.
 
-Uses synthetic data by default so the script runs immediately without any
-external dataset.  Replace the `build_synthetic_dataset` call with real data
-once the CATH / SCOPe loader exists (Phase 0).
+Data sources
+------------
+  Synthetic (default):  random sequences + random labels, no download needed.
+  Real data (--real-data): downloads proteinea/secondary_structure_prediction
+                            from Hugging Face (~20 MB, cached after first use).
 
 Usage
 -----
-  python scripts/train_baseline.py                      # BiLSTM, SS3, synthetic
-  python scripts/train_baseline.py --model transformer  # Transformer variant
-  python scripts/train_baseline.py --epochs 20 --lr 3e-4 --batch-size 32
+  # Synthetic data (quick smoke-test)
+  python scripts/train_baseline.py
+
+  # Real SS3 data
+  python scripts/train_baseline.py --real-data
+
+  # Real SS8 data, Transformer, more epochs
+  python scripts/train_baseline.py --real-data --ss-type ss8 --model transformer --epochs 20
+
+  # Limit real data size for a fast trial run
+  python scripts/train_baseline.py --real-data --max-samples 500
+
+  # Full options
   python scripts/train_baseline.py --help
 """
 
@@ -24,17 +36,17 @@ from pathlib import Path
 import torch
 import torch.nn as nn
 from torch import Tensor
-from torch.nn.utils.rnn import pad_sequence
 from torch.utils.data import DataLoader, random_split
 
 # Make the repo root importable when running as a script
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from src.data.protein_dataset import PAD_IDX, ProteinDataset
+from src.data.loaders import SS3_LABEL_MAP, SS8_LABEL_MAP, collate_fn, load_ss_dataset
 from src.models.baseline import SS3_CLASSES, SS8_CLASSES, ModelKind, build_model
 
 # ---------------------------------------------------------------------------
-# Synthetic dataset (placeholder until real data loader is ready)
+# Synthetic dataset (no download required — useful for CI and quick tests)
 # ---------------------------------------------------------------------------
 
 _AA = "ACDEFGHIKLMNPQRSTVWY"
@@ -47,10 +59,7 @@ def build_synthetic_dataset(
     n_classes: int = SS3_CLASSES,
     seed: int = 42,
 ) -> ProteinDataset:
-    """Generate random amino acid sequences with random SS labels.
-
-    This is purely for smoke-testing the training pipeline.
-    """
+    """Generate random amino acid sequences with random per-residue SS labels."""
     rng = random.Random(seed)
     sequences, labels = [], []
     for _ in range(n):
@@ -66,28 +75,24 @@ def build_synthetic_dataset(
 # DataLoader helpers
 # ---------------------------------------------------------------------------
 
-def collate_fn(batch: list[tuple[Tensor, Tensor]]) -> tuple[Tensor, Tensor]:
-    """Pad a batch of (tokens, labels) pairs to the same length."""
-    seqs, lbls = zip(*batch)
-    return (
-        pad_sequence(seqs, batch_first=True, padding_value=PAD_IDX),
-        pad_sequence(lbls, batch_first=True, padding_value=-1),   # -1 → ignored by loss
-    )
-
-
 def make_loaders(
     dataset: ProteinDataset,
     val_fraction: float = 0.15,
     batch_size: int = 16,
     seed: int = 42,
 ) -> tuple[DataLoader, DataLoader]:
+    """Split dataset into train/val DataLoaders with padding collation."""
     n_val = max(1, int(len(dataset) * val_fraction))
     n_train = len(dataset) - n_val
     train_ds, val_ds = random_split(
         dataset, [n_train, n_val], generator=torch.Generator().manual_seed(seed)
     )
-    train_loader = DataLoader(train_ds, batch_size=batch_size, shuffle=True, collate_fn=collate_fn)
-    val_loader = DataLoader(val_ds, batch_size=batch_size, shuffle=False, collate_fn=collate_fn)
+    train_loader = DataLoader(
+        train_ds, batch_size=batch_size, shuffle=True, collate_fn=collate_fn
+    )
+    val_loader = DataLoader(
+        val_ds, batch_size=batch_size, shuffle=False, collate_fn=collate_fn
+    )
     return train_loader, val_loader
 
 
@@ -105,7 +110,7 @@ def run_epoch(
     """Run one full pass over `loader`.
 
     Returns:
-        (mean_loss, accuracy) — both scalars, accuracy ignores PAD positions.
+        (mean_loss, accuracy) where accuracy ignores PAD and -1 label positions.
     """
     training = optimizer is not None
     model.train() if training else model.eval()
@@ -154,29 +159,40 @@ def train(args: argparse.Namespace) -> None:
     device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
     print(f"Device: {device}")
 
-    # --- data ---
-    print("Building synthetic dataset...")
-    dataset = build_synthetic_dataset(n=args.n_samples, n_classes=args.n_classes)
+    # --- data source ---
+    n_classes = SS8_CLASSES if args.ss_type == "ss8" else SS3_CLASSES
+
+    if args.real_data:
+        dataset = load_ss_dataset(
+            ss_type=args.ss_type,
+            max_samples=args.max_samples,
+        )
+    else:
+        print(f"Building synthetic dataset ({args.n_samples} sequences)…")
+        dataset = build_synthetic_dataset(n=args.n_samples, n_classes=n_classes)
+
     train_loader, val_loader = make_loaders(
         dataset, batch_size=args.batch_size, val_fraction=0.15
     )
     print(
-        f"  Train: {len(train_loader.dataset)} samples | "  # type: ignore[arg-type]
-        f"Val: {len(val_loader.dataset)} samples"           # type: ignore[arg-type]
+        f"  Train: {len(train_loader.dataset):,} samples | "  # type: ignore[arg-type]
+        f"Val:   {len(val_loader.dataset):,} samples"          # type: ignore[arg-type]
     )
 
     # --- model ---
-    model = build_model(kind=args.model, n_classes=args.n_classes).to(device)
-    print(f"Model: {args.model}  |  Parameters: {model.count_parameters():,}")
+    model = build_model(kind=args.model, n_classes=n_classes).to(device)
+    print(f"Model: {args.model}  |  Classes: {n_classes}  |  Parameters: {model.count_parameters():,}")
 
-    # --- loss: ignore padding (-1) and weight classes equally ---
+    # --- optimisation ---
+    # CrossEntropyLoss ignores -1 labels (padded positions and unknown chars)
     criterion = nn.CrossEntropyLoss(ignore_index=-1)
     optimizer = torch.optim.AdamW(model.parameters(), lr=args.lr, weight_decay=1e-4)
     scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optimizer, T_max=args.epochs)
 
     # --- loop ---
     best_val_acc = 0.0
-    print(f"\n{'Epoch':>5}  {'Train Loss':>10}  {'Train Acc':>9}  {'Val Loss':>8}  {'Val Acc':>7}  {'Time':>6}")
+    header = f"\n{'Epoch':>5}  {'Train Loss':>10}  {'Train Acc':>9}  {'Val Loss':>8}  {'Val Acc':>7}  {'Time':>6}"
+    print(header)
     print("-" * 62)
 
     for epoch in range(1, args.epochs + 1):
@@ -196,11 +212,19 @@ def train(args: argparse.Namespace) -> None:
 
     print(f"\nBest val accuracy: {best_val_acc:.1%}")
 
-    # --- optional checkpoint save ---
+    # --- optional checkpoint ---
     if args.save:
         save_path = Path(args.save)
         save_path.parent.mkdir(parents=True, exist_ok=True)
-        torch.save({"model_state": model.state_dict(), "args": vars(args)}, save_path)
+        torch.save(
+            {
+                "model_state": model.state_dict(),
+                "args": vars(args),
+                "n_classes": n_classes,
+                "ss_type": args.ss_type,
+            },
+            save_path,
+        )
         print(f"Checkpoint saved to {save_path}")
 
 
@@ -209,21 +233,47 @@ def train(args: argparse.Namespace) -> None:
 # ---------------------------------------------------------------------------
 
 def parse_args() -> argparse.Namespace:
-    p = argparse.ArgumentParser(description="Train baseline secondary structure model")
-    p.add_argument("--model", choices=["bilstm", "transformer"], default="bilstm",
-                   help="Model architecture (default: bilstm)")
-    p.add_argument("--n-classes", type=int, choices=[3, 8], default=SS3_CLASSES,
-                   help="Number of SS classes: 3 (SS3) or 8 (SS8) (default: 3)")
-    p.add_argument("--epochs", type=int, default=10,
-                   help="Number of training epochs (default: 10)")
-    p.add_argument("--batch-size", type=int, default=16,
-                   help="Batch size (default: 16)")
-    p.add_argument("--lr", type=float, default=1e-3,
-                   help="Learning rate (default: 1e-3)")
-    p.add_argument("--n-samples", type=int, default=512,
-                   help="Number of synthetic sequences (default: 512)")
-    p.add_argument("--save", type=str, default=None,
-                   help="Path to save model checkpoint, e.g. checkpoints/baseline.pt")
+    p = argparse.ArgumentParser(
+        description="Train baseline secondary structure model",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+
+    # Data
+    data = p.add_argument_group("data")
+    data.add_argument(
+        "--real-data", action="store_true",
+        help="Load real data from Hugging Face instead of synthetic sequences",
+    )
+    data.add_argument(
+        "--ss-type", choices=["ss3", "ss8"], default="ss3",
+        help="Secondary structure label set (only used with --real-data)",
+    )
+    data.add_argument(
+        "--max-samples", type=int, default=None,
+        help="Cap number of real sequences loaded (default: all ~10,800)",
+    )
+    data.add_argument(
+        "--n-samples", type=int, default=512,
+        help="Number of synthetic sequences (ignored with --real-data)",
+    )
+
+    # Model
+    model = p.add_argument_group("model")
+    model.add_argument(
+        "--model", choices=["bilstm", "transformer"], default="bilstm",
+        help="Model architecture",
+    )
+
+    # Training
+    train_g = p.add_argument_group("training")
+    train_g.add_argument("--epochs",     type=int,   default=10)
+    train_g.add_argument("--batch-size", type=int,   default=16)
+    train_g.add_argument("--lr",         type=float, default=1e-3)
+    train_g.add_argument(
+        "--save", type=str, default=None,
+        help="Path to save checkpoint, e.g. checkpoints/baseline.pt",
+    )
+
     return p.parse_args()
 
 

--- a/src/data/loaders.py
+++ b/src/data/loaders.py
@@ -1,0 +1,211 @@
+"""
+Real protein secondary structure dataset loaders.
+
+Primary source
+--------------
+  proteinea/secondary_structure_prediction  (Hugging Face)
+  - 10,800 amino acid sequences from CATH/SCOPe
+  - Columns: input (sequence), dssp3 (3-state SS), dssp8 (8-state SS)
+  - Single 'train' split; we carve our own val set in the training script
+
+Label alphabets
+---------------
+  SS3 (3-state):  C=coil, H=helix, E=strand
+  SS8 (8-state):  C=coil, H=α-helix, E=strand, G=3₁₀-helix,
+                  I=π-helix, T=turn, S=bend, B=β-bridge
+
+Public API
+----------
+  load_ss_dataset(ss_type, ...)  → ProteinDataset
+  collate_fn(batch)              → (padded_tokens, padded_labels)
+  SS3_LABEL_MAP, SS8_LABEL_MAP   — char → int index dicts
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Literal, Optional
+
+import torch
+from torch import Tensor
+from torch.nn.utils.rnn import pad_sequence
+from torch.utils.data import DataLoader
+
+from src.data.protein_dataset import PAD_IDX, ProteinDataset
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Label vocabularies
+# ---------------------------------------------------------------------------
+
+# Integer indices are stable; DO NOT reorder without updating trained models.
+SS3_LABEL_MAP: dict[str, int] = {"C": 0, "H": 1, "E": 2}
+SS8_LABEL_MAP: dict[str, int] = {
+    "C": 0,
+    "H": 1,
+    "E": 2,
+    "G": 3,   # 3₁₀-helix
+    "I": 4,   # π-helix
+    "T": 5,   # turn
+    "S": 6,   # bend
+    "B": 7,   # β-bridge
+}
+
+SSType = Literal["ss3", "ss8"]
+
+HF_DATASET_ID = "proteinea/secondary_structure_prediction"
+_LABEL_COL = {"ss3": "dssp3", "ss8": "dssp8"}
+
+
+# ---------------------------------------------------------------------------
+# Label conversion helpers
+# ---------------------------------------------------------------------------
+
+def _label_str_to_tensor(label_str: str, label_map: dict[str, int]) -> Tensor:
+    """Convert a per-residue label string (e.g. 'CCHHEE') to a long tensor.
+
+    Characters not in `label_map` are mapped to -1 so CrossEntropyLoss
+    can ignore them via ignore_index=-1.
+    """
+    return torch.tensor(
+        [label_map.get(ch, -1) for ch in label_str],
+        dtype=torch.long,
+    )
+
+
+def _is_valid_row(seq: str, label: str) -> bool:
+    """Return True if sequence and label are non-empty and the same length."""
+    return bool(seq) and bool(label) and len(seq) == len(label)
+
+
+# ---------------------------------------------------------------------------
+# Main loader
+# ---------------------------------------------------------------------------
+
+def load_ss_dataset(
+    ss_type: SSType = "ss3",
+    max_samples: Optional[int] = None,
+    cache_dir: Optional[str] = None,
+) -> ProteinDataset:
+    """Download and return a ProteinDataset of real secondary structure data.
+
+    Uses the ``proteinea/secondary_structure_prediction`` dataset from
+    Hugging Face (≈ 10,800 sequences, ~20 MB download, cached after first use).
+
+    Args:
+        ss_type:     "ss3" for 3-state (C/H/E) or "ss8" for 8-state labels.
+        max_samples: Cap the number of sequences loaded (useful for quick runs).
+        cache_dir:   Optional HuggingFace cache directory override.
+
+    Returns:
+        ProteinDataset with sequences and per-residue integer label tensors.
+
+    Raises:
+        ImportError:  if the ``datasets`` library is not installed.
+        RuntimeError: if the download fails and no cached version exists.
+    """
+    try:
+        from datasets import load_dataset as hf_load  # type: ignore[import]
+    except ImportError as exc:
+        raise ImportError(
+            "The 'datasets' package is required for real data loading.\n"
+            "Install it with:  pip install datasets"
+        ) from exc
+
+    label_col = _LABEL_COL[ss_type]
+    label_map = SS3_LABEL_MAP if ss_type == "ss3" else SS8_LABEL_MAP
+
+    logger.info("Downloading %s (split='train', task=%s)…", HF_DATASET_ID, ss_type)
+    print(f"Loading {HF_DATASET_ID} [{ss_type}] from Hugging Face…")
+
+    try:
+        hf_ds = hf_load(
+            HF_DATASET_ID,
+            split="train",
+            cache_dir=cache_dir,
+            trust_remote_code=False,
+        )
+    except Exception as exc:
+        raise RuntimeError(
+            f"Failed to load {HF_DATASET_ID!r} from Hugging Face.\n"
+            f"Check your internet connection or pass a local cache_dir.\n"
+            f"Original error: {exc}"
+        ) from exc
+
+    sequences: list[str] = []
+    labels: list[Tensor] = []
+    skipped = 0
+
+    iterable = hf_ds if max_samples is None else hf_ds.select(range(min(max_samples * 2, len(hf_ds))))
+
+    for row in iterable:
+        seq: str = row["input"].strip()
+        lbl_str: str = row[label_col].strip()
+
+        if not _is_valid_row(seq, lbl_str):
+            skipped += 1
+            continue
+
+        sequences.append(seq)
+        labels.append(_label_str_to_tensor(lbl_str, label_map))
+
+        if max_samples is not None and len(sequences) >= max_samples:
+            break
+
+    if skipped:
+        logger.warning("Skipped %d malformed rows (len mismatch or empty).", skipped)
+
+    print(
+        f"  Loaded {len(sequences):,} sequences "
+        f"({'ss3' if ss_type == 'ss3' else 'ss8'}, "
+        f"{len(label_map)} classes, "
+        f"{skipped} rows skipped)"
+    )
+
+    return ProteinDataset(sequences, labels=labels)
+
+
+# ---------------------------------------------------------------------------
+# Shared collate function (imported by training scripts)
+# ---------------------------------------------------------------------------
+
+def collate_fn(batch: list[tuple[Tensor, Tensor]]) -> tuple[Tensor, Tensor]:
+    """Pad a variable-length batch of (tokens, labels) to the same length.
+
+    Token padding uses PAD_IDX (0); label padding uses -1 so that
+    CrossEntropyLoss(ignore_index=-1) ignores those positions.
+    """
+    seqs, lbls = zip(*batch)
+    return (
+        pad_sequence(seqs, batch_first=True, padding_value=PAD_IDX),
+        pad_sequence(lbls, batch_first=True, padding_value=-1),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Quick smoke-test:  python -m src.data.loaders
+# ---------------------------------------------------------------------------
+
+if __name__ == "__main__":
+    import sys
+
+    ss = sys.argv[1] if len(sys.argv) > 1 else "ss3"
+    assert ss in ("ss3", "ss8"), "Usage: python -m src.data.loaders [ss3|ss8]"
+
+    ds = load_ss_dataset(ss_type=ss, max_samples=200)  # type: ignore[arg-type]
+    print(ds)
+
+    # Spot-check first sample
+    tokens, lbl = ds[0]
+    print(f"  Sequence length : {len(tokens)}")
+    print(f"  Label length    : {len(lbl)}")
+    print(f"  Unique labels   : {sorted(lbl.unique().tolist())}")
+    assert len(tokens) == len(lbl), "Token / label length mismatch!"
+
+    # DataLoader round-trip
+    loader = DataLoader(ds, batch_size=8, collate_fn=collate_fn)
+    batch_tok, batch_lbl = next(iter(loader))
+    print(f"  Batch tokens    : {batch_tok.shape}")
+    print(f"  Batch labels    : {batch_lbl.shape}")
+    print("Smoke-test passed.")


### PR DESCRIPTION
## Summary

Resolves Issue #4 — Load Real Secondary Structure Data.

Adds `src/data/loaders.py` to download and parse the `proteinea/secondary_structure_prediction` dataset from Hugging Face, and updates the training script with a `--real-data` flag so the full pipeline can be exercised on real biological sequences.

## What Changed

### `src/data/loaders.py` (new)
- **`load_ss_dataset(ss_type, max_samples, cache_dir)`** — downloads `proteinea/secondary_structure_prediction` (10,792 sequences, ~20 MB, cached after first use). Supports `ss3` (3-state: C/H/E) and `ss8` (8-state: C/H/E/G/I/T/S/B).
- **`SS3_LABEL_MAP` / `SS8_LABEL_MAP`** — stable `char → int` dicts; indices are pinned so trained checkpoints stay valid.
- **`_label_str_to_tensor`** — converts per-residue label strings to `torch.long`; unknown characters map to `-1` (ignored by `CrossEntropyLoss(ignore_index=-1)`).
- **`collate_fn`** — moved here from `train_baseline.py`; now shared across all scripts.
- Graceful `ImportError` if `datasets` package is missing; `RuntimeError` with a helpful message if the download fails.
- `__main__` smoke-test: loads 200 real sequences, validates shapes, runs a DataLoader round-trip.

### `scripts/train_baseline.py` (updated)
- Imports `collate_fn` from `loaders` (removes duplicate).
- **`--real-data`** flag: switches data source from synthetic to Hugging Face.
- **`--ss-type {ss3,ss8}`**: selects label set (default `ss3`).
- **`--max-samples`**: caps sequences loaded for quick trial runs.
- `n_classes` is now derived from `ss_type` automatically.

## Reviewer Notes

- The HF dataset has a single `train` split; the script carves a 15% val set with `random_split`. A held-out test split (CB513) can be added in a follow-up once the mask column is parsed.
- `X` residues in real sequences map to `UNK_IDX=1` via the existing `tokenize()` function — no changes to `ProteinDataset` needed.
- Symlink warning on Windows (HF cache) is cosmetic and does not affect correctness.

## Test Plan

```bash
# Smoke-test the loader directly (downloads ~20 MB on first run)
python -m src.data.loaders ss3

# Train on real SS3 data, 5 epochs
python scripts/train_baseline.py --real-data --max-samples 300 --epochs 5

# Train on real SS8 data with Transformer
python scripts/train_baseline.py --real-data --ss-type ss8 --model transformer --epochs 10
```

**Verified result** (BiLSTM, 300 real sequences, 5 epochs):
```
Epoch  Train Loss  Train Acc   Val Loss  Val Acc
    1      1.0499     50.1%      0.8740   60.8% *
    4      0.8439     62.0%      0.8307   63.0% *
Best val accuracy: 63.0%
```
63% on real data vs 33% random-chance baseline — the model is learning genuine secondary structure signal.

- [ ] Unit tests for `load_ss_dataset` and `collate_fn` to be added in `tests/data/test_loaders.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)