### PR TITLE
docs: define agent roles and multi-agent workflow guidelines (Issue #5)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,62 +2,43 @@
 
 ## Multi-Agent Development Workflow
 
-This project uses a **multi-agent** development model where specialized AI agents collaborate on distinct concerns. Each agent operates on a focused domain and hands off through GitHub Issues and Pull Requests.
+This project uses a **multi-agent** development model where specialized AI agents collaborate
+on distinct concerns, handing off through GitHub Issues and Pull Requests.
 
-### Agent Roles
+For the full reference — agent role definitions, handoff protocols, label schema, issue and
+PR templates, and interaction rules — see
+[docs/multi_agent_workflow.md](docs/multi_agent_workflow.md).
+
+### Agent Roles (summary)
 
 | Agent | Responsibilities |
 |---|---|
-| **Architect** | High-level design, module interfaces, phase planning |
+| **Architect** | High-level design, module interfaces, phase planning, opens issues |
 | **Coder** | Implementation, refactoring, bug fixes |
-| **Researcher** | Literature review, algorithm selection, benchmarking |
-| **Reviewer** | Code review, correctness checks, security |
-| **Tester** | Writing and running tests, coverage analysis |
+| **Researcher** | Literature review, algorithm selection, data sourcing, writes to `docs/` |
+| **Reviewer** | Code review, correctness checks, PR approval |
+| **Tester** | Unit tests, coverage, CI health |
 
-### Workflow
-
-```
-Issue opened (Architect or human)
-   │
-   ▼
-Agent picks up issue → creates feature branch
-   │
-   ▼
-Implementation on branch
-   │
-   ▼
-Pull Request opened → Reviewer agent reviews
-   │
-   ▼
-Merge to main after approval
-```
-
-### Issue Conventions
-
-- Prefix issue titles with the phase: `[Phase 0]`, `[Phase 1]`, etc., or `[Infra]` for infrastructure.
-- Assign a `agent:coder`, `agent:researcher`, etc. label to indicate the intended agent.
-- Keep issues atomic — one task, one issue.
-
-### Branch Naming
+### Workflow (summary)
 
 ```
-phase0/data-pipeline
-phase1/contact-map-model
-infra/ci-setup
-fix/fape-loss-nan
+Issue opened (Architect) → Agent implements on branch → PR → Reviewer approves → Merge
 ```
 
-### Code Standards
+---
 
-- **Python 3.10+**; type-annotate all public functions.
+## Code Standards
+
+- **Python 3.10+** — type-annotate all public functions.
 - Formatting: `black` (line length 100).
 - Linting: `ruff`.
 - Tests live in `tests/`; mirror the `src/` directory structure.
 - Run `pytest tests/` before opening a PR; all tests must pass.
+- Every new module includes a smoke-test under `if __name__ == "__main__"`.
 
-### Commit Messages
+## Commit Messages
 
-Use the conventional commits format:
+Use [Conventional Commits](https://www.conventionalcommits.org/):
 
 ```
 feat(data): add CATH dataset loader
@@ -66,13 +47,22 @@ docs(readme): update Phase 1 description
 test(training): add coverage for gradient clipping
 ```
 
-### Adding a New Module
+## Branch Naming
+
+```
+phase0/data-pipeline
+phase1/contact-map-model
+infra/ci-setup
+fix/fape-loss-nan
+```
+
+## Adding a New Module
 
 1. Create the file under the appropriate `src/` subdirectory.
-2. Add a corresponding test file under `tests/`.
+2. Add a corresponding test file under `tests/` (or open a `[Test]` follow-up issue).
 3. Export public symbols from the subpackage `__init__.py` only when they form a stable API.
 4. Update `configs/` with any new hyperparameters.
 
-### Questions
+## Questions
 
 Open a GitHub Discussion or tag the relevant agent in an issue comment.

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,6 +13,7 @@ of each component to make good engineering decisions during implementation.
 | [alphafold2_overview.md](alphafold2_overview.md) | What AlphaFold2 is, why it was a breakthrough, and its scientific and practical impact |
 | [key_papers.md](key_papers.md) | Structured summaries of the landmark papers (AF1 and AF2), with authors, venues, and key contributions |
 | [key_techniques.md](key_techniques.md) | Deep-dive explanations of every major technical innovation: MSA processing, Evoformer, pair representations, Structure Module, recycling, FAPE loss, and more |
+| [multi_agent_workflow.md](multi_agent_workflow.md) | Full agent role definitions, handoff protocols, GitHub label schema, issue and PR templates, and interaction rules |
 
 ## How to use these notes
 

--- a/docs/multi_agent_workflow.md
+++ b/docs/multi_agent_workflow.md
@@ -1,0 +1,227 @@
+# Multi-Agent Development Workflow
+
+This document defines the roles, responsibilities, and interaction protocols for the
+multi-agent development model used in mini-alphafold. It is the authoritative reference
+for how agents collaborate via GitHub Issues and Pull Requests.
+
+---
+
+## Agent Roster
+
+### Architect
+| Field | Detail |
+|---|---|
+| **Primary concern** | System design, module boundaries, phase planning |
+| **Consumes** | Project goals, Researcher outputs, feedback from Coder/Tester |
+| **Produces** | Architecture decision records, interface specs, phase roadmaps, Issue briefs |
+| **Owns** | `docs/`, top-level `README.md`, module `__init__.py` public APIs |
+| **Does NOT** | Write implementation code, run experiments |
+
+The Architect opens issues for other agents and defines acceptance criteria. When a
+phase boundary is reached, the Architect reviews whether the system design needs
+updating before the next phase begins.
+
+---
+
+### Coder
+| Field | Detail |
+|---|---|
+| **Primary concern** | Implementation, refactoring, bug fixes |
+| **Consumes** | Issues from Architect, specs from Researcher, bug reports from Tester |
+| **Produces** | Feature branches, Pull Requests, passing smoke-tests |
+| **Owns** | `src/`, `scripts/`, `configs/` |
+| **Does NOT** | Decide architecture, write formal test suites (that is Tester's role) |
+
+The Coder includes a smoke-test (`if __name__ == "__main__"`) in every new module
+so the code can be verified immediately. Formal unit tests are filed as a follow-up
+issue for the Tester.
+
+---
+
+### Researcher
+| Field | Detail |
+|---|---|
+| **Primary concern** | Literature, algorithm selection, benchmarking, data sourcing |
+| **Consumes** | Phase goals from Architect, questions tagged `agent:researcher` |
+| **Produces** | Notes in `docs/`, dataset recommendations, hyperparameter recommendations, benchmark baselines |
+| **Owns** | `docs/key_papers.md`, `docs/key_techniques.md`, experiment analysis |
+| **Does NOT** | Write production code, open implementation issues |
+
+The Researcher's outputs are written to `docs/` and referenced in implementation
+issues so the Coder has the necessary context.
+
+---
+
+### Reviewer
+| Field | Detail |
+|---|---|
+| **Primary concern** | Code correctness, consistency, security, style |
+| **Consumes** | Pull Requests |
+| **Produces** | PR review comments, approval or change requests |
+| **Owns** | PR review process |
+| **Does NOT** | Implement fixes (files comments; Coder acts on them) |
+
+The Reviewer checks that:
+- The implementation matches the issue's acceptance criteria
+- Type annotations are present on all public functions
+- No obvious numerical bugs (e.g. loss applied to PAD tokens, shape mismatches)
+- No security issues (e.g. shell injection in scripts, untrusted data executed)
+- Code style matches project standards (`black`, `ruff`)
+
+---
+
+### Tester
+| Field | Detail |
+|---|---|
+| **Primary concern** | Test coverage, regression prevention, CI health |
+| **Consumes** | Merged PRs, bug reports |
+| **Produces** | Test files in `tests/`, coverage reports, CI configuration |
+| **Owns** | `tests/` directory structure, CI pipeline |
+| **Does NOT** | Write production features |
+
+Every module in `src/` should have a corresponding test file in `tests/` mirroring
+the directory structure (e.g. `src/data/loaders.py` → `tests/data/test_loaders.py`).
+
+---
+
+## Issue Lifecycle
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                        OPEN ISSUE                           │
+│  Title: [Phase N] Short description                         │
+│  Label: agent:<role>                                        │
+│  Body:  requirements + acceptance criteria                  │
+└──────────────────────────┬──────────────────────────────────┘
+                           │
+                    Assigned agent
+                    picks up issue
+                           │
+                           ▼
+┌─────────────────────────────────────────────────────────────┐
+│                     IN PROGRESS                             │
+│  Branch: phase<N>/short-description                        │
+│  Agent works; may comment on issue if blocked               │
+└──────────────────────────┬──────────────────────────────────┘
+                           │
+                    Work complete
+                           │
+                           ▼
+┌─────────────────────────────────────────────────────────────┐
+│                    PULL REQUEST                             │
+│  Title matches issue title                                  │
+│  Body: what changed, why, reviewer notes, test plan         │
+│  Links issue: "Resolves #N"                                 │
+└──────────────────────────┬──────────────────────────────────┘
+                           │
+                    Reviewer approves
+                           │
+                           ▼
+┌─────────────────────────────────────────────────────────────┐
+│                      MERGED                                 │
+│  Issue closed automatically via "Resolves #N"              │
+│  Follow-up issues opened if needed (e.g. tests, docs)       │
+└─────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Handoff Protocols
+
+### Architect → Coder
+The Architect opens an issue with:
+- A clear **task statement** (one sentence)
+- **Acceptance criteria** (bulleted, verifiable)
+- Links to relevant `docs/` files or prior issues for context
+- The label `agent:coder`
+
+The Coder does not start work until an issue exists with acceptance criteria.
+
+### Researcher → Coder
+When research produces an implementation recommendation, the Researcher either:
+- Comments on the relevant open issue with findings, or
+- Opens a new issue tagged `agent:coder` referencing the research doc in `docs/`
+
+### Coder → Reviewer
+The Coder opens a PR and:
+- Fills out the full PR template (summary, what changed, reviewer notes, test plan)
+- Self-reviews the diff before requesting review
+- Marks the PR draft if work is incomplete
+
+### Reviewer → Coder
+The Reviewer leaves inline comments on specific lines. For blocking issues, the
+Reviewer requests changes. For non-blocking suggestions, the Reviewer uses the
+`nit:` prefix in comments. The Coder addresses all blocking comments before re-requesting review.
+
+### Coder → Tester
+After a PR is merged, if formal unit tests were deferred, the Coder opens a follow-up
+issue: `[Test] Module name — unit tests` tagged `agent:tester`.
+
+---
+
+## GitHub Label Schema
+
+| Label | Meaning |
+|---|---|
+| `agent:architect` | Issue is for the Architect agent |
+| `agent:coder` | Issue is for the Coder agent |
+| `agent:researcher` | Issue is for the Researcher agent |
+| `agent:reviewer` | Issue is for the Reviewer agent |
+| `agent:tester` | Issue is for the Tester agent |
+| `phase:0` – `phase:3` | Which project phase this belongs to |
+| `infra` | Infrastructure, CI, tooling — not tied to a phase |
+| `blocked` | Issue cannot proceed; blocking dependency noted in comments |
+| `good first issue` | Well-scoped, low-risk, good for onboarding |
+
+---
+
+## Issue Template
+
+```markdown
+## Task
+One-sentence description of what needs to be done.
+
+## Context
+Why this is needed. Link to relevant docs/, prior issues, or research.
+
+## Acceptance Criteria
+- [ ] Specific, verifiable requirement 1
+- [ ] Specific, verifiable requirement 2
+- [ ] Smoke-test or test command that must pass
+
+## Out of Scope
+List anything explicitly NOT required in this issue.
+```
+
+---
+
+## PR Template
+
+```markdown
+## Summary
+One or two sentences. Which issue does this resolve?
+
+## What Changed
+Bullet list of files modified and what each change does.
+
+## Reviewer Notes
+Anything non-obvious the reviewer should know: design decisions,
+tradeoffs, known limitations, or deferred work.
+
+## Test Plan
+- [ ] Command or test that was run and passed
+- [ ] Known gaps (follow-up issue #N filed)
+```
+
+---
+
+## Interaction Rules
+
+1. **One issue, one agent.** If a task spans multiple agents, split it into multiple issues.
+2. **No direct pushes to `main`.** All changes go through a PR, regardless of size.
+3. **Issues before code.** The Coder does not implement something that has no issue.
+4. **Atomic PRs.** A PR should be reviewable in one sitting. If it is growing large, split the issue.
+5. **Follow-up issues over scope creep.** If you discover additional work while implementing,
+   open a new issue rather than expanding the current PR.
+6. **Comments over silence.** If an agent is blocked, it comments on the issue immediately
+   rather than waiting. Other agents can unblock or re-scope.


### PR DESCRIPTION
## Summary

Resolves Issue #5 — Multi-Agent Workflow.

Defines agent roles in detail and establishes the guidelines for how agents interact via Issues and Pull Requests.

## What Changed

### `docs/multi_agent_workflow.md` (new)
Full reference document covering:
- **Agent roster** — Architect, Coder, Researcher, Reviewer, Tester: what each consumes, produces, owns, and explicitly does not do
- **Issue lifecycle** — ASCII diagram of the open → in-progress → PR → merged flow
- **Handoff protocols** — specific rules for every agent-to-agent transition (Architect→Coder, Researcher→Coder, Coder→Reviewer, Reviewer→Coder, Coder→Tester)
- **GitHub label schema** — `agent:*`, `phase:*`, `infra`, `blocked`, `good first issue`
- **Issue template** — task, context, acceptance criteria, out-of-scope sections
- **PR template** — summary, what changed, reviewer notes, test plan
- **Six interaction rules** — no direct pushes to main, issues before code, atomic PRs, follow-up issues over scope creep, etc.

### `CONTRIBUTING.md` (updated)
- Slimmed to a concise quick-reference; links to `docs/multi_agent_workflow.md` for full details
- Eliminates duplication between the two files
- Added explicit smoke-test requirement for every new module

### `docs/README.md` (updated)
- Added `multi_agent_workflow.md` to the file index

## Reviewer Notes

- No code changes — documentation only.
- `CONTRIBUTING.md` intentionally kept short so new contributors see the essentials immediately; depth lives in `docs/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)