### PR TITLE
feat(models): coarse 3D structure prediction + FAPE loss (Phase 2)

### DIFF
--- a/scripts/train_contact.py
+++ b/scripts/train_contact.py
@@ -1,0 +1,508 @@
+"""
+Contact map prediction training script.
+
+Data sources
+------------
+  Synthetic (default): random sequences with block-structured contact maps.
+                        No download required — good for verifying the pipeline.
+  Real (--pdb-ids):    Comma-separated PDB IDs downloaded from RCSB.
+                        Requires Biopython.  Example: --pdb-ids 1UBQ,4HHB,1CRN
+
+Contact definition
+------------------
+  Cα–Cα distance < threshold (default 8 Å).
+  Pairs with |i-j| < sep_min (default 6) are excluded from loss and metrics
+  to focus on non-trivial contacts.
+
+Metrics
+-------
+  Precision@L   : precision among the top-L highest-confidence predictions
+                  (L = sequence length).  Standard benchmark metric.
+  Precision@L/2 : same for top L/2 predictions.
+  Precision@L/5 : same for top L/5 predictions.
+  Recall@0.5    : recall at sigmoid threshold 0.5.
+
+Usage
+-----
+  # Synthetic smoke-test
+  python scripts/train_contact.py
+
+  # Real PDB data, Transformer, focal loss
+  python scripts/train_contact.py --pdb-ids 1UBQ,4HHB,1CRN,2KHO,1L2Y \\
+      --model transformer --loss focal --epochs 20
+
+  # More options
+  python scripts/train_contact.py --help
+"""
+
+from __future__ import annotations
+
+import argparse
+import random
+import sys
+import tempfile
+import time
+import urllib.request
+from pathlib import Path
+from typing import Optional
+
+import torch
+import torch.nn as nn
+from torch import Tensor
+from torch.nn.utils.rnn import pad_sequence
+from torch.utils.data import DataLoader, Dataset, random_split
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from src.data.protein_dataset import PAD_IDX, tokenize
+from src.models.contact_predictor import ModelKind, build_contact_model
+from src.training.losses import LossKind, contact_loss, make_contact_mask
+
+# ---------------------------------------------------------------------------
+# Contact map utilities
+# ---------------------------------------------------------------------------
+
+CA_IDX = 1   # index of Cα in BACKBONE_ATOMS = [N, CA, C, O]
+
+
+def coords_to_contact_map(
+    coords: Tensor,
+    threshold: float = 8.0,
+    sep_min: int = 6,
+) -> Tensor:
+    """Compute a binary contact map from backbone coordinates.
+
+    Args:
+        coords:    (L, 4, 3) float32 — backbone atom positions (N, CA, C, O).
+        threshold: Cα–Cα distance cutoff in Å (default 8.0).
+        sep_min:   Pairs with |i-j| < sep_min are set to 0 (not contact).
+
+    Returns:
+        contact: (L, L) float32 tensor with values in {0.0, 1.0}.
+    """
+    ca = coords[:, CA_IDX, :]                           # (L, 3)
+    diff = ca.unsqueeze(0) - ca.unsqueeze(1)            # (L, L, 3)
+    dist = diff.pow(2).sum(-1).sqrt()                   # (L, L)
+    contact = (dist < threshold).float()
+
+    # Zero out short-range pairs (local secondary structure)
+    L = coords.size(0)
+    idx = torch.arange(L, device=coords.device)
+    sep = (idx.unsqueeze(0) - idx.unsqueeze(1)).abs()
+    contact[sep < sep_min] = 0.0
+
+    return contact
+
+
+# ---------------------------------------------------------------------------
+# Dataset
+# ---------------------------------------------------------------------------
+
+class ContactDataset(Dataset):
+    """Dataset of (sequence_tokens, contact_map) pairs.
+
+    Args:
+        sequences:    List of amino acid strings.
+        contact_maps: List of (L, L) float32 tensors.
+    """
+
+    def __init__(self, sequences: list[str], contact_maps: list[Tensor]) -> None:
+        assert len(sequences) == len(contact_maps)
+        self.tokens: list[Tensor] = [tokenize(s) for s in sequences]
+        self.contact_maps = contact_maps
+
+    def __len__(self) -> int:
+        return len(self.tokens)
+
+    def __getitem__(self, idx: int) -> tuple[Tensor, Tensor]:
+        return self.tokens[idx], self.contact_maps[idx]
+
+
+def collate_contact(
+    batch: list[tuple[Tensor, Tensor]],
+) -> tuple[Tensor, Tensor, Tensor]:
+    """Pad a variable-length batch of (tokens, contact_map) pairs.
+
+    Returns:
+        tokens:    (B, L_max) long — padded token sequences.
+        contacts:  (B, L_max, L_max) float32 — padded contact maps.
+        lengths:   (B,) int — original sequence lengths (for mask).
+    """
+    seqs, maps = zip(*batch)
+    lengths = torch.tensor([s.size(0) for s in seqs], dtype=torch.long)
+    L = int(lengths.max().item())
+
+    # Pad tokens
+    tokens = pad_sequence(seqs, batch_first=True, padding_value=PAD_IDX)  # (B, L)
+
+    # Pad contact maps to (B, L, L)
+    B = len(maps)
+    contacts = torch.zeros(B, L, L, dtype=torch.float32)
+    for i, cm in enumerate(maps):
+        l = cm.size(0)
+        contacts[i, :l, :l] = cm
+
+    return tokens, contacts, lengths
+
+
+# ---------------------------------------------------------------------------
+# Synthetic data (no download required)
+# ---------------------------------------------------------------------------
+
+_AA = "ACDEFGHIKLMNPQRSTVWY"
+
+
+def _synthetic_contact_map(length: int, threshold: float = 8.0) -> Tensor:
+    """Generate a plausible-looking synthetic contact map.
+
+    Uses a simple block-diagonal structure (mimicking secondary structure)
+    plus a few randomly placed long-range contacts.
+    """
+    cm = torch.zeros(length, length)
+
+    # Local contacts: |i-j| in [6, 12] with decreasing probability
+    for i in range(length):
+        for offset in range(6, min(13, length - i)):
+            j = i + offset
+            if random.random() < 0.4:
+                cm[i, j] = cm[j, i] = 1.0
+
+    # Long-range contacts: random sparse pairs
+    n_lr = max(1, length // 20)
+    for _ in range(n_lr):
+        i = random.randint(0, length - 1)
+        j = random.randint(0, length - 1)
+        if abs(i - j) >= 6:
+            cm[i, j] = cm[j, i] = 1.0
+
+    return cm
+
+
+def build_synthetic_dataset(
+    n: int = 256,
+    min_len: int = 30,
+    max_len: int = 100,
+    seed: int = 42,
+) -> ContactDataset:
+    """Random amino acid sequences with structured synthetic contact maps."""
+    rng = random.Random(seed)
+    sequences, maps = [], []
+    for _ in range(n):
+        length = rng.randint(min_len, max_len)
+        seq = "".join(rng.choice(_AA) for _ in range(length))
+        sequences.append(seq)
+        maps.append(_synthetic_contact_map(length))
+    return ContactDataset(sequences, maps)
+
+
+# ---------------------------------------------------------------------------
+# Real data: download PDB files and parse coordinates
+# ---------------------------------------------------------------------------
+
+def build_real_dataset(
+    pdb_ids: list[str],
+    threshold: float = 8.0,
+    sep_min: int = 6,
+) -> ContactDataset:
+    """Download PDB files from RCSB and build a ContactDataset.
+
+    Args:
+        pdb_ids:   List of 4-character PDB identifiers (e.g. ["1UBQ", "4HHB"]).
+        threshold: Cα–Cα contact distance cutoff in Å.
+        sep_min:   Minimum sequence separation included in contact maps.
+
+    Returns:
+        ContactDataset with real sequences and ground-truth contact maps.
+    """
+    try:
+        from src.data.pdb_parser import parse_structure_file
+    except ImportError as exc:
+        raise ImportError("pdb_parser requires Biopython: pip install biopython") from exc
+
+    sequences, maps = [], []
+
+    for pdb_id in pdb_ids:
+        url = f"https://files.rcsb.org/download/{pdb_id.upper()}.pdb"
+        print(f"  Downloading {pdb_id.upper()} from RCSB…")
+        try:
+            with tempfile.NamedTemporaryFile(suffix=".pdb", delete=False) as tmp:
+                tmp_path = Path(tmp.name)
+            urllib.request.urlretrieve(url, tmp_path)
+            data = parse_structure_file(tmp_path)
+            tmp_path.unlink(missing_ok=True)
+        except Exception as exc:
+            print(f"  WARNING: skipping {pdb_id} — {exc}")
+            continue
+
+        cm = coords_to_contact_map(data.coords, threshold=threshold, sep_min=sep_min)
+        sequences.append(data.sequence)
+        maps.append(cm)
+        print(
+            f"  {pdb_id.upper()} chain {data.chain_id}: "
+            f"L={len(data.sequence)}, "
+            f"contacts={int(cm.sum() // 2)} pairs"
+        )
+
+    if not sequences:
+        raise RuntimeError("No structures loaded successfully.")
+
+    return ContactDataset(sequences, maps)
+
+
+# ---------------------------------------------------------------------------
+# Metrics
+# ---------------------------------------------------------------------------
+
+def precision_at_k(
+    logits: Tensor,
+    targets: Tensor,
+    mask: Tensor,
+    k_factor: float = 1.0,
+) -> float:
+    """Precision among the top k*L highest-confidence predictions.
+
+    Args:
+        logits:   (B, L, L) raw contact logits.
+        targets:  (B, L, L) ground-truth contacts.
+        mask:     (B, L, L) valid pairs (excludes PAD and short-range).
+        k_factor: Multiplier on L (1.0 → Precision@L, 0.5 → @L/2, etc.)
+
+    Returns:
+        Mean precision across batch samples.
+    """
+    precisions = []
+    B = logits.size(0)
+
+    for b in range(B):
+        L = int(mask[b].any(dim=1).sum().item())   # effective length
+        k = max(1, int(k_factor * L))
+
+        valid_logits = logits[b][mask[b]]
+        valid_targets = targets[b][mask[b]]
+
+        if valid_logits.numel() < k:
+            continue
+
+        top_k_idx = valid_logits.topk(k).indices
+        precisions.append(valid_targets[top_k_idx].float().mean().item())
+
+    return float(sum(precisions) / max(len(precisions), 1))
+
+
+def recall_at_threshold(
+    logits: Tensor,
+    targets: Tensor,
+    mask: Tensor,
+    threshold: float = 0.5,
+) -> float:
+    """Recall at a fixed sigmoid probability threshold."""
+    probs = torch.sigmoid(logits)
+    tp, fn = 0, 0
+    B = logits.size(0)
+    for b in range(B):
+        t = targets[b][mask[b]]
+        p = (probs[b][mask[b]] >= threshold).float()
+        tp += (p * t).sum().item()
+        fn += ((1 - p) * t).sum().item()
+    return tp / max(tp + fn, 1)
+
+
+# ---------------------------------------------------------------------------
+# DataLoader
+# ---------------------------------------------------------------------------
+
+def make_loaders(
+    dataset: ContactDataset,
+    val_fraction: float = 0.2,
+    batch_size: int = 4,
+    seed: int = 42,
+) -> tuple[DataLoader, DataLoader]:
+    n_val = max(1, int(len(dataset) * val_fraction))
+    n_train = len(dataset) - n_val
+    train_ds, val_ds = random_split(
+        dataset, [n_train, n_val], generator=torch.Generator().manual_seed(seed)
+    )
+    train_loader = DataLoader(
+        train_ds, batch_size=batch_size, shuffle=True, collate_fn=collate_contact
+    )
+    val_loader = DataLoader(
+        val_ds, batch_size=batch_size, shuffle=False, collate_fn=collate_contact
+    )
+    return train_loader, val_loader
+
+
+# ---------------------------------------------------------------------------
+# One epoch
+# ---------------------------------------------------------------------------
+
+def run_epoch(
+    model: nn.Module,
+    loader: DataLoader,
+    optimizer: Optional[torch.optim.Optimizer],
+    loss_kind: LossKind,
+    sep_min: int,
+    device: torch.device,
+) -> tuple[float, float, float, float]:
+    """Run one pass.  Returns (mean_loss, P@L, P@L/5, recall@0.5)."""
+    training = optimizer is not None
+    model.train() if training else model.eval()
+
+    total_loss = 0.0
+    all_logits, all_targets, all_masks = [], [], []
+
+    ctx = torch.enable_grad() if training else torch.no_grad()
+    with ctx:
+        for tokens, contacts, lengths in loader:
+            tokens = tokens.to(device)
+            contacts = contacts.to(device)
+            lengths = lengths.to(device)
+
+            logits = model(tokens)                                    # (B, L, L)
+            mask = make_contact_mask(lengths, logits.size(-1),
+                                     sep_min=sep_min, device=device)  # (B, L, L)
+
+            loss = contact_loss(logits, contacts, mask, kind=loss_kind)
+
+            if training:
+                optimizer.zero_grad()
+                loss.backward()
+                nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)
+                optimizer.step()
+
+            total_loss += loss.item() * tokens.size(0)
+            all_logits.append(logits.detach().cpu())
+            all_targets.append(contacts.cpu())
+            all_masks.append(mask.cpu())
+
+    n = len(loader.dataset)   # type: ignore[arg-type]
+    all_l = torch.cat([pad_to_same(x, all_logits) for x in all_logits], dim=0) if len(all_logits) > 1 else all_logits[0]
+    all_t = torch.cat([pad_to_same(x, all_targets) for x in all_targets], dim=0) if len(all_targets) > 1 else all_targets[0]
+    all_m = torch.cat([pad_to_same(x, all_masks) for x in all_masks], dim=0) if len(all_masks) > 1 else all_masks[0]
+
+    p_at_l    = precision_at_k(all_l, all_t, all_m, k_factor=1.0)
+    p_at_l5   = precision_at_k(all_l, all_t, all_m, k_factor=0.2)
+    rec       = recall_at_threshold(all_l, all_t, all_m)
+
+    return total_loss / n, p_at_l, p_at_l5, rec
+
+
+def pad_to_same(tensor: Tensor, group: list[Tensor]) -> Tensor:
+    """Pad a (B, L, L) tensor to the maximum L in the group."""
+    max_L = max(t.size(-1) for t in group)
+    L = tensor.size(-1)
+    if L == max_L:
+        return tensor
+    pad = max_L - L
+    return torch.nn.functional.pad(tensor, (0, pad, 0, pad))
+
+
+# ---------------------------------------------------------------------------
+# Training loop
+# ---------------------------------------------------------------------------
+
+def train(args: argparse.Namespace) -> None:
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    print(f"Device: {device}")
+
+    # --- data ---
+    if args.pdb_ids:
+        print(f"Loading real PDB structures: {args.pdb_ids}")
+        pdb_list = [p.strip().upper() for p in args.pdb_ids.split(",")]
+        dataset = build_real_dataset(pdb_list, threshold=args.threshold, sep_min=args.sep_min)
+    else:
+        print(f"Building synthetic dataset ({args.n_samples} sequences)…")
+        dataset = build_synthetic_dataset(n=args.n_samples)
+
+    train_loader, val_loader = make_loaders(
+        dataset, batch_size=args.batch_size, val_fraction=0.2
+    )
+    print(
+        f"  Train: {len(train_loader.dataset):,} | "   # type: ignore[arg-type]
+        f"Val: {len(val_loader.dataset):,}"             # type: ignore[arg-type]
+    )
+
+    # --- model ---
+    model = build_contact_model(
+        kind=args.model, pair_dim=args.pair_dim
+    ).to(device)
+    print(f"Model: {model}")
+
+    # --- optimisation ---
+    optimizer = torch.optim.AdamW(model.parameters(), lr=args.lr, weight_decay=1e-4)
+    scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optimizer, T_max=args.epochs)
+
+    # --- loop ---
+    best_p_at_l = 0.0
+    hdr = (f"\n{'Epoch':>5}  {'Loss':>8}  {'P@L':>7}  {'P@L/5':>7}  "
+           f"{'Recall':>7}  {'Time':>6}")
+    print(hdr)
+    print("-" * 52)
+
+    for epoch in range(1, args.epochs + 1):
+        t0 = time.time()
+        tr_loss, _, _, _ = run_epoch(
+            model, train_loader, optimizer, args.loss, args.sep_min, device
+        )
+        val_loss, p_at_l, p_at_l5, rec = run_epoch(
+            model, val_loader, None, args.loss, args.sep_min, device
+        )
+        scheduler.step()
+
+        elapsed = time.time() - t0
+        marker = " *" if p_at_l > best_p_at_l else ""
+        best_p_at_l = max(best_p_at_l, p_at_l)
+
+        print(
+            f"{epoch:>5}  {val_loss:>8.4f}  {p_at_l:>6.1%}  "
+            f"{p_at_l5:>6.1%}  {rec:>6.1%}  {elapsed:>5.1f}s{marker}"
+        )
+
+    print(f"\nBest val Precision@L: {best_p_at_l:.1%}")
+
+    if args.save:
+        save_path = Path(args.save)
+        save_path.parent.mkdir(parents=True, exist_ok=True)
+        torch.save({"model_state": model.state_dict(), "args": vars(args)}, save_path)
+        print(f"Checkpoint saved to {save_path}")
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(
+        description="Train contact map predictor",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+
+    data = p.add_argument_group("data")
+    data.add_argument(
+        "--pdb-ids", type=str, default=None,
+        help="Comma-separated PDB IDs to download (e.g. 1UBQ,4HHB,1CRN). "
+             "Omit to use synthetic data.",
+    )
+    data.add_argument("--n-samples", type=int, default=256,
+                      help="Synthetic sequences to generate")
+    data.add_argument("--threshold", type=float, default=8.0,
+                      help="Ca-Ca contact distance cutoff in Angstroms")
+    data.add_argument("--sep-min", type=int, default=6,
+                      help="Minimum sequence separation for contact pairs")
+
+    model_g = p.add_argument_group("model")
+    model_g.add_argument("--model", choices=["bilstm", "transformer"], default="bilstm")
+    model_g.add_argument("--pair-dim", type=int, default=64,
+                         help="Contact head pair dimension")
+    model_g.add_argument("--loss", choices=["bce", "focal"], default="bce")
+
+    train_g = p.add_argument_group("training")
+    train_g.add_argument("--epochs",     type=int,   default=10)
+    train_g.add_argument("--batch-size", type=int,   default=4)
+    train_g.add_argument("--lr",         type=float, default=1e-3)
+    train_g.add_argument("--save",       type=str,   default=None)
+
+    return p.parse_args()
+
+
+if __name__ == "__main__":
+    train(parse_args())

--- a/scripts/train_structure.py
+++ b/scripts/train_structure.py
@@ -1,0 +1,443 @@
+"""
+Coarse 3D structure prediction training script (Phase 2).
+
+Trains a StructureModule end-to-end to predict Cα backbone coordinates
+using FAPE loss, then evaluates with TM-score and GDT-TS.
+
+Data sources
+------------
+  Synthetic (default):  random sequences with helix/sheet coordinate patterns.
+                         No download — validates the training pipeline.
+  Real (--pdb-ids):     Comma-separated PDB IDs downloaded from RCSB.
+                         Example: --pdb-ids 1UBQ,4HHB,1CRN,2KHO,1VII
+
+Metrics (after Kabsch alignment)
+----------------------------------
+  RMSD        : Cα root-mean-square deviation (Å) — lower is better.
+  TM-score    : Template modelling score [0, 1] — > 0.5 ≈ same fold.
+  GDT-TS      : % residues within 1/2/4/8 Å — higher is better.
+
+Usage
+-----
+  # Synthetic smoke-test
+  python scripts/train_structure.py
+
+  # Real structures, Transformer encoder
+  python scripts/train_structure.py --pdb-ids 1UBQ,1CRN,4HHB,1L2Y,1VII \\
+      --model transformer --epochs 30 --lr 5e-4
+
+  python scripts/train_structure.py --help
+"""
+
+from __future__ import annotations
+
+import argparse
+import math
+import random
+import sys
+import tempfile
+import time
+import urllib.request
+from pathlib import Path
+from typing import Optional
+
+import torch
+import torch.nn as nn
+from torch import Tensor
+from torch.nn.utils.rnn import pad_sequence
+from torch.utils.data import DataLoader, Dataset, random_split
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from src.data.protein_dataset import PAD_IDX, tokenize
+from src.models.structure_module import ModelKind, StructureOutput, build_structure_model
+from src.training.losses import backbone_rmsd, fape_loss, make_backbone_frames
+
+# ---------------------------------------------------------------------------
+# Dataset
+# ---------------------------------------------------------------------------
+
+class StructureDataset(Dataset):
+    """Pairs of (token sequence, backbone coordinates).
+
+    Args:
+        sequences:  List of amino acid strings.
+        coords:     List of (L, 4, 3) float32 tensors — atom order [N, CA, C, O].
+    """
+
+    def __init__(self, sequences: list[str], coords: list[Tensor]) -> None:
+        assert len(sequences) == len(coords)
+        self.tokens: list[Tensor] = [tokenize(s) for s in sequences]
+        self.coords = coords
+
+    def __len__(self) -> int:
+        return len(self.tokens)
+
+    def __getitem__(self, idx: int) -> tuple[Tensor, Tensor]:
+        return self.tokens[idx], self.coords[idx]
+
+
+def collate_structure(
+    batch: list[tuple[Tensor, Tensor]],
+) -> tuple[Tensor, Tensor, Tensor]:
+    """Pad tokens and backbone coords to the batch maximum length.
+
+    Returns:
+        tokens:  (B, L) long
+        coords:  (B, L, 4, 3) float32 — padded with zeros
+        lengths: (B,) int
+    """
+    seqs, coord_list = zip(*batch)
+    lengths = torch.tensor([s.size(0) for s in seqs], dtype=torch.long)
+    L = int(lengths.max().item())
+    B = len(seqs)
+
+    tokens = pad_sequence(seqs, batch_first=True, padding_value=PAD_IDX)
+
+    coords_padded = torch.zeros(B, L, 4, 3, dtype=torch.float32)
+    for i, c in enumerate(coord_list):
+        l = c.size(0)
+        coords_padded[i, :l] = c
+
+    return tokens, coords_padded, lengths
+
+
+# ---------------------------------------------------------------------------
+# Synthetic data
+# ---------------------------------------------------------------------------
+
+_AA = "ACDEFGHIKLMNPQRSTVWY"
+
+
+def _helix_coords(length: int) -> Tensor:
+    """Approximate alpha-helix backbone (all 4 atoms placed at Cα-like positions)."""
+    coords = torch.zeros(length, 4, 3)
+    r, rise, twist = 2.3, 1.5, math.radians(100)
+    for i in range(length):
+        angle = i * twist
+        ca = torch.tensor([r * math.cos(angle), r * math.sin(angle), i * rise])
+        # Approximate N and C by small offsets along helix axis
+        n  = ca + torch.tensor([-0.5,  0.1, -0.4])
+        c  = ca + torch.tensor([ 0.5, -0.1,  0.4])
+        o  = c  + torch.tensor([ 0.0,  0.0,  1.2])
+        coords[i] = torch.stack([n, ca, c, o])
+    return coords
+
+
+def build_synthetic_dataset(
+    n: int = 128,
+    min_len: int = 20,
+    max_len: int = 80,
+    seed: int = 42,
+) -> StructureDataset:
+    """Random sequences with approximate helix-like coordinates (+ noise).
+
+    The coordinates are geometrically plausible enough to test the training
+    pipeline, but carry no real structural signal.
+    """
+    rng = random.Random(seed)
+    sequences, coords_list = [], []
+    for _ in range(n):
+        length = rng.randint(min_len, max_len)
+        seq = "".join(rng.choice(_AA) for _ in range(length))
+        c = _helix_coords(length) + torch.randn(length, 4, 3) * 0.5
+        sequences.append(seq)
+        coords_list.append(c)
+    return StructureDataset(sequences, coords_list)
+
+
+# ---------------------------------------------------------------------------
+# Real data
+# ---------------------------------------------------------------------------
+
+def build_real_dataset(pdb_ids: list[str]) -> StructureDataset:
+    """Download PDB files from RCSB and build a StructureDataset."""
+    try:
+        from src.data.pdb_parser import parse_structure_file
+    except ImportError as exc:
+        raise ImportError("pdb_parser requires Biopython: pip install biopython") from exc
+
+    sequences, coords_list = [], []
+    for pdb_id in pdb_ids:
+        url = f"https://files.rcsb.org/download/{pdb_id.upper()}.pdb"
+        print(f"  Downloading {pdb_id.upper()}…")
+        try:
+            with tempfile.NamedTemporaryFile(suffix=".pdb", delete=False) as tmp:
+                tmp_path = Path(tmp.name)
+            urllib.request.urlretrieve(url, tmp_path)
+            data = parse_structure_file(tmp_path)
+            tmp_path.unlink(missing_ok=True)
+        except Exception as exc:
+            print(f"  WARNING: skipping {pdb_id} — {exc}")
+            continue
+
+        sequences.append(data.sequence)
+        coords_list.append(data.coords)
+        print(f"  {pdb_id.upper()} chain {data.chain_id}: L={len(data.sequence)}")
+
+    if not sequences:
+        raise RuntimeError("No structures loaded.")
+    return StructureDataset(sequences, coords_list)
+
+
+# ---------------------------------------------------------------------------
+# Evaluation metrics (require Kabsch alignment)
+# ---------------------------------------------------------------------------
+
+def kabsch_align(P: Tensor, Q: Tensor) -> Tensor:
+    """Align point cloud P onto Q using the Kabsch algorithm.
+
+    Args:
+        P: (L, 3) — predicted coordinates (to be rotated).
+        Q: (L, 3) — target coordinates (reference, unchanged).
+
+    Returns:
+        P_aligned: (L, 3) — P after optimal rotation + translation onto Q.
+    """
+    P_c = P - P.mean(dim=0, keepdim=True)
+    Q_c = Q - Q.mean(dim=0, keepdim=True)
+
+    H = P_c.T @ Q_c                                   # (3, 3) covariance
+    U, _, Vt = torch.linalg.svd(H, full_matrices=True)
+
+    # Correct for reflection (det < 0 means improper rotation)
+    d = torch.linalg.det(Vt.T @ U.T)
+    D = torch.diag(torch.tensor([1.0, 1.0, d.item()], device=P.device))
+    R = Vt.T @ D @ U.T                                # (3, 3) proper rotation
+
+    return P_c @ R.T + Q.mean(dim=0, keepdim=True)
+
+
+def _d0(L: int) -> float:
+    """TM-score length normalisation parameter."""
+    if L < 22:
+        return 0.5
+    return 1.24 * (L - 15) ** (1 / 3) - 1.8
+
+
+def tm_score(pred_ca: Tensor, true_ca: Tensor, mask: Tensor) -> float:
+    """TM-score after Kabsch alignment (per-sample, averaged over batch).
+
+    Args:
+        pred_ca: (B, L, 3)
+        true_ca: (B, L, 3)
+        mask:    (B, L) bool — non-PAD residues
+
+    Returns:
+        Mean TM-score across the batch.
+    """
+    scores = []
+    for b in range(pred_ca.size(0)):
+        m = mask[b]
+        if m.sum() < 3:
+            continue
+        P = pred_ca[b][m]
+        Q = true_ca[b][m]
+        L = Q.size(0)
+        d0 = _d0(L)
+        P_al = kabsch_align(P, Q)
+        di = (P_al - Q).pow(2).sum(-1).sqrt()         # (L,)
+        score = (1 / (1 + (di / d0) ** 2)).mean().item()
+        scores.append(score)
+    return sum(scores) / max(len(scores), 1)
+
+
+def gdt_ts(pred_ca: Tensor, true_ca: Tensor, mask: Tensor) -> float:
+    """GDT-TS score after Kabsch alignment.
+
+    GDT-TS = (GDT_P1 + GDT_P2 + GDT_P4 + GDT_P8) / 4
+    where GDT_Pk = fraction of residues within k Å.
+
+    Returns:
+        Mean GDT-TS across the batch (0–1 scale).
+    """
+    scores = []
+    thresholds = [1.0, 2.0, 4.0, 8.0]
+    for b in range(pred_ca.size(0)):
+        m = mask[b]
+        if m.sum() < 3:
+            continue
+        P = pred_ca[b][m]
+        Q = true_ca[b][m]
+        P_al = kabsch_align(P, Q)
+        di = (P_al - Q).pow(2).sum(-1).sqrt()
+        gdt = sum((di < t).float().mean().item() for t in thresholds) / 4.0
+        scores.append(gdt)
+    return sum(scores) / max(len(scores), 1)
+
+
+# ---------------------------------------------------------------------------
+# One epoch
+# ---------------------------------------------------------------------------
+
+def run_epoch(
+    model: nn.Module,
+    loader: DataLoader,
+    optimizer: Optional[torch.optim.Optimizer],
+    device: torch.device,
+    d_clamp: float,
+) -> tuple[float, float, float, float]:
+    """Returns (mean_fape, mean_rmsd, mean_tm, mean_gdt)."""
+    training = optimizer is not None
+    model.train() if training else model.eval()
+
+    total_fape = 0.0
+    all_pred, all_true, all_masks = [], [], []
+
+    ctx = torch.enable_grad() if training else torch.no_grad()
+    with ctx:
+        for tokens, coords, lengths in loader:
+            tokens = tokens.to(device)
+            coords = coords.to(device)
+
+            seq_mask = torch.arange(tokens.size(1), device=device).unsqueeze(0) < lengths.to(device).unsqueeze(1)
+
+            out: StructureOutput = model(tokens)
+            true_R, true_t = make_backbone_frames(coords)   # (B, L, 3, 3), (B, L, 3)
+
+            loss = fape_loss(
+                pred_t=out.ca_coords,
+                true_t=true_t,
+                pred_R=out.rotations if out.has_frames else true_R,
+                true_R=true_R,
+                seq_mask=seq_mask,
+                d_clamp=d_clamp,
+            )
+
+            if training:
+                optimizer.zero_grad()
+                loss.backward()
+                nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)
+                optimizer.step()
+
+            total_fape += loss.item() * tokens.size(0)
+            all_pred.append(out.ca_coords.detach().cpu())
+            all_true.append(true_t.cpu())
+            all_masks.append(seq_mask.cpu())
+
+    n = len(loader.dataset)   # type: ignore[arg-type]
+
+    # Collect eval tensors (pad to common L for metric computation)
+    max_L = max(t.size(1) for t in all_pred)
+
+    def pad2d(t: Tensor) -> Tensor:
+        pad = max_L - t.size(1)
+        return torch.nn.functional.pad(t, (0, 0, 0, pad)) if pad > 0 else t
+
+    pred_cat = torch.cat([pad2d(t) for t in all_pred], dim=0)
+    true_cat = torch.cat([pad2d(t) for t in all_true], dim=0)
+    mask_cat = torch.cat([
+        torch.nn.functional.pad(m, (0, max_L - m.size(1))) for m in all_masks
+    ], dim=0)
+
+    rmsd = backbone_rmsd(pred_cat, true_cat, mask_cat).item()
+    tm   = tm_score(pred_cat, true_cat, mask_cat)
+    gdt  = gdt_ts(pred_cat, true_cat, mask_cat)
+
+    return total_fape / n, rmsd, tm, gdt
+
+
+# ---------------------------------------------------------------------------
+# Training loop
+# ---------------------------------------------------------------------------
+
+def train(args: argparse.Namespace) -> None:
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    print(f"Device: {device}")
+
+    # --- data ---
+    if args.pdb_ids:
+        pdb_list = [p.strip().upper() for p in args.pdb_ids.split(",")]
+        print(f"Loading real PDB structures: {pdb_list}")
+        dataset = build_real_dataset(pdb_list)
+    else:
+        print(f"Building synthetic dataset ({args.n_samples} sequences)…")
+        dataset = build_synthetic_dataset(n=args.n_samples)
+
+    n_val = max(1, int(len(dataset) * 0.2))
+    n_train = len(dataset) - n_val
+    train_ds, val_ds = random_split(
+        dataset, [n_train, n_val], generator=torch.Generator().manual_seed(42)
+    )
+    train_loader = DataLoader(train_ds, batch_size=args.batch_size,
+                              shuffle=True, collate_fn=collate_structure)
+    val_loader   = DataLoader(val_ds,   batch_size=args.batch_size,
+                              shuffle=False, collate_fn=collate_structure)
+    print(f"  Train: {len(train_ds):,} | Val: {len(val_ds):,}")
+
+    # --- model ---
+    model = build_structure_model(
+        kind=args.model, use_frames=True
+    ).to(device)
+    print(f"Model: {model}")
+
+    optimizer = torch.optim.AdamW(model.parameters(), lr=args.lr, weight_decay=1e-4)
+    scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optimizer, T_max=args.epochs)
+
+    # --- loop ---
+    best_tm = 0.0
+    hdr = (f"\n{'Epoch':>5}  {'FAPE':>7}  {'RMSD':>7}  "
+           f"{'TM-score':>8}  {'GDT-TS':>7}  {'Time':>6}")
+    print(hdr)
+    print("-" * 54)
+
+    for epoch in range(1, args.epochs + 1):
+        t0 = time.time()
+        tr_fape, _, _, _ = run_epoch(
+            model, train_loader, optimizer, device, args.d_clamp
+        )
+        val_fape, rmsd, tm, gdt = run_epoch(
+            model, val_loader, None, device, args.d_clamp
+        )
+        scheduler.step()
+
+        elapsed = time.time() - t0
+        marker = " *" if tm > best_tm else ""
+        best_tm = max(best_tm, tm)
+
+        print(
+            f"{epoch:>5}  {val_fape:>7.4f}  {rmsd:>7.2f}  "
+            f"{tm:>8.4f}  {gdt:>7.3f}  {elapsed:>5.1f}s{marker}"
+        )
+
+    print(f"\nBest val TM-score: {best_tm:.4f}")
+
+    if args.save:
+        save_path = Path(args.save)
+        save_path.parent.mkdir(parents=True, exist_ok=True)
+        torch.save({"model_state": model.state_dict(), "args": vars(args)}, save_path)
+        print(f"Checkpoint saved → {save_path}")
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(
+        description="Train coarse 3D structure predictor (Phase 2)",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    data = p.add_argument_group("data")
+    data.add_argument(
+        "--pdb-ids", type=str, default=None,
+        help="Comma-separated PDB IDs (e.g. 1UBQ,4HHB). Omit for synthetic.",
+    )
+    data.add_argument("--n-samples", type=int, default=128)
+
+    model_g = p.add_argument_group("model")
+    model_g.add_argument("--model", choices=["bilstm", "transformer"], default="bilstm")
+
+    train_g = p.add_argument_group("training")
+    train_g.add_argument("--epochs",     type=int,   default=10)
+    train_g.add_argument("--batch-size", type=int,   default=4)
+    train_g.add_argument("--lr",         type=float, default=1e-3)
+    train_g.add_argument("--d-clamp",    type=float, default=10.0,
+                         help="FAPE clamping distance in Angstroms")
+    train_g.add_argument("--save",       type=str,   default=None)
+
+    return p.parse_args()
+
+
+if __name__ == "__main__":
+    train(parse_args())

--- a/src/models/baseline.py
+++ b/src/models/baseline.py
@@ -96,6 +96,18 @@ class BiLSTMModel(nn.Module):
         # Bidirectional doubles the output dim
         self.head = ResidueHead(hidden_dim * 2, n_classes, dropout=dropout)
 
+    def encode(self, tokens: Tensor) -> Tensor:
+        """Return per-residue hidden states before the classification head.
+
+        Args:
+            tokens: (batch, seq_len)
+        Returns:
+            h: (batch, seq_len, 2*hidden_dim)
+        """
+        x = self.embedding(tokens)
+        x, _ = self.lstm(x)
+        return x
+
     def forward(self, tokens: Tensor) -> Tensor:
         """
         Args:
@@ -103,9 +115,7 @@ class BiLSTMModel(nn.Module):
         Returns:
             logits: (batch, seq_len, n_classes)
         """
-        x = self.embedding(tokens)           # (B, L, embed_dim)
-        x, _ = self.lstm(x)                  # (B, L, 2*hidden_dim)
-        return self.head(x)                  # (B, L, n_classes)
+        return self.head(self.encode(tokens))
 
     def count_parameters(self) -> int:
         return sum(p.numel() for p in self.parameters() if p.requires_grad)
@@ -181,6 +191,19 @@ class TransformerModel(nn.Module):
         )
         self.head = ResidueHead(d_model, n_classes, dropout=dropout)
 
+    def encode(self, tokens: Tensor) -> Tensor:
+        """Return per-residue hidden states before the classification head.
+
+        Args:
+            tokens: (batch, seq_len)
+        Returns:
+            h: (batch, seq_len, d_model)
+        """
+        pad_mask = tokens == self.padding_idx
+        x = self.embedding(tokens)
+        x = self.pos_enc(x)
+        return self.encoder(x, src_key_padding_mask=pad_mask)
+
     def forward(self, tokens: Tensor) -> Tensor:
         """
         Args:
@@ -188,13 +211,7 @@ class TransformerModel(nn.Module):
         Returns:
             logits: (batch, seq_len, n_classes)
         """
-        # Build padding mask: True where token == PAD (encoder ignores these)
-        pad_mask = tokens == self.padding_idx                # (B, L)
-
-        x = self.embedding(tokens)                          # (B, L, d_model)
-        x = self.pos_enc(x)
-        x = self.encoder(x, src_key_padding_mask=pad_mask)  # (B, L, d_model)
-        return self.head(x)                                  # (B, L, n_classes)
+        return self.head(self.encode(tokens))
 
     def count_parameters(self) -> int:
         return sum(p.numel() for p in self.parameters() if p.requires_grad)

--- a/src/models/contact_predictor.py
+++ b/src/models/contact_predictor.py
@@ -1,0 +1,185 @@
+"""
+Residue-residue contact map predictor for mini-alphafold.
+
+Architecture:  sequence encoder  →  ContactHead  →  (B, L, L) logits
+
+The ContactHead takes per-residue hidden states (B, L, H) and produces a
+symmetric matrix of raw logits.  Apply sigmoid to get contact probabilities.
+
+Symmetry is guaranteed by construction:
+    pair_feat[b, i, j] = 0.5 * (q[b,i]*k[b,j] + k[b,i]*q[b,j])
+which is invariant under swapping i and j.
+
+Memory note: the ContactHead materialises an (B, L, L, pair_dim) tensor,
+so it is O(L²).  For sequences ≤ 500 residues this is fine on CPU/GPU.
+
+Public API
+----------
+  ContactPredictor          — full model (encoder + head)
+  ContactHead               — pairwise head (reusable standalone)
+  build_contact_model(kind) — factory
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+import torch
+import torch.nn as nn
+from torch import Tensor
+
+from src.data.protein_dataset import PAD_IDX, VOCAB_SIZE
+from src.models.baseline import (
+    BiLSTMModel,
+    ModelKind,
+    SS3_CLASSES,
+    TransformerModel,
+    build_model,
+)
+
+
+# ---------------------------------------------------------------------------
+# Pairwise contact head
+# ---------------------------------------------------------------------------
+
+class ContactHead(nn.Module):
+    """Projects per-residue hidden states to a symmetric (L, L) contact map.
+
+    Args:
+        hidden_dim: Dimensionality of encoder output (input to this head).
+        pair_dim:   Internal dimension of the pairwise feature vector.
+        dropout:    Dropout before the output linear layer.
+    """
+
+    def __init__(
+        self,
+        hidden_dim: int,
+        pair_dim: int = 64,
+        dropout: float = 0.1,
+    ) -> None:
+        super().__init__()
+        self.proj_q = nn.Linear(hidden_dim, pair_dim, bias=False)
+        self.proj_k = nn.Linear(hidden_dim, pair_dim, bias=False)
+        self.out = nn.Sequential(
+            nn.LayerNorm(pair_dim),
+            nn.ReLU(),
+            nn.Dropout(dropout),
+            nn.Linear(pair_dim, 1),
+        )
+
+    def forward(self, h: Tensor) -> Tensor:
+        """
+        Args:
+            h: (batch, seq_len, hidden_dim) — encoder output.
+        Returns:
+            logits: (batch, seq_len, seq_len) — raw (pre-sigmoid) contact scores,
+                    symmetric along the last two dimensions.
+        """
+        q = self.proj_q(h)   # (B, L, d)
+        k = self.proj_k(h)   # (B, L, d)
+
+        # Symmetric pairwise features: 0.5*(q_i*k_j + k_i*q_j)
+        # Broadcasting: (B, L, 1, d) * (B, 1, L, d) → (B, L, L, d)
+        pair = 0.5 * (
+            q.unsqueeze(2) * k.unsqueeze(1)   # q_i * k_j
+            + k.unsqueeze(2) * q.unsqueeze(1) # k_i * q_j
+        )                                      # (B, L, L, pair_dim)
+
+        return self.out(pair).squeeze(-1)      # (B, L, L)
+
+
+# ---------------------------------------------------------------------------
+# Full contact predictor
+# ---------------------------------------------------------------------------
+
+class ContactPredictor(nn.Module):
+    """Sequence encoder + ContactHead for residue-residue contact prediction.
+
+    Args:
+        encoder:    A BiLSTMModel or TransformerModel.  Its encode() method
+                    is used to obtain per-residue hidden states.
+        pair_dim:   Internal dimension of the ContactHead.
+        dropout:    Dropout in the ContactHead.
+    """
+
+    def __init__(
+        self,
+        encoder: BiLSTMModel | TransformerModel,
+        pair_dim: int = 64,
+        dropout: float = 0.1,
+    ) -> None:
+        super().__init__()
+        self.encoder = encoder
+        hidden_dim = _encoder_hidden_dim(encoder)
+        self.contact_head = ContactHead(hidden_dim, pair_dim=pair_dim, dropout=dropout)
+
+    def forward(self, tokens: Tensor) -> Tensor:
+        """
+        Args:
+            tokens: (batch, seq_len) — integer token indices from ProteinDataset.
+        Returns:
+            logits: (batch, seq_len, seq_len) — raw contact logits (apply sigmoid
+                    for probabilities).  Symmetric: logits[b,i,j] == logits[b,j,i].
+        """
+        h = self.encoder.encode(tokens)          # (B, L, H)
+        return self.contact_head(h)              # (B, L, L)
+
+    def predict_proba(self, tokens: Tensor) -> Tensor:
+        """Convenience wrapper: forward → sigmoid → (B, L, L) contact probabilities."""
+        return torch.sigmoid(self(tokens))
+
+    def count_parameters(self) -> int:
+        return sum(p.numel() for p in self.parameters() if p.requires_grad)
+
+    def __repr__(self) -> str:
+        enc = type(self.encoder).__name__
+        return (
+            f"ContactPredictor(encoder={enc}, "
+            f"params={self.count_parameters():,})"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Internal helper
+# ---------------------------------------------------------------------------
+
+def _encoder_hidden_dim(encoder: BiLSTMModel | TransformerModel) -> int:
+    """Return the output dimensionality of an encoder's encode() method."""
+    if isinstance(encoder, BiLSTMModel):
+        return encoder.lstm.hidden_size * 2   # bidirectional
+    if isinstance(encoder, TransformerModel):
+        return encoder.embedding.embedding_dim
+    raise TypeError(f"Unsupported encoder type: {type(encoder)}")
+
+
+# ---------------------------------------------------------------------------
+# Factory
+# ---------------------------------------------------------------------------
+
+def build_contact_model(
+    kind: ModelKind = "bilstm",
+    pair_dim: int = 64,
+    dropout: float = 0.1,
+    **encoder_kwargs,
+) -> ContactPredictor:
+    """Build a ContactPredictor with the specified encoder backbone.
+
+    Args:
+        kind:            "bilstm" or "transformer".
+        pair_dim:        Internal dimension of the ContactHead.
+        dropout:         Dropout in ContactHead.
+        **encoder_kwargs: Forwarded to the encoder constructor
+                          (e.g. hidden_dim=256, num_layers=3).
+
+    Returns:
+        ContactPredictor ready for training.
+
+    Example::
+
+        model = build_contact_model("bilstm", hidden_dim=128)
+        logits = model(tokens)   # (B, L, L)
+    """
+    # n_classes is irrelevant for the encoder when used in ContactPredictor
+    # (the SS head is never called), but the encoder needs a value to build.
+    encoder = build_model(kind=kind, n_classes=SS3_CLASSES, **encoder_kwargs)
+    return ContactPredictor(encoder, pair_dim=pair_dim, dropout=dropout)

--- a/src/models/structure_module.py
+++ b/src/models/structure_module.py
@@ -1,0 +1,243 @@
+"""
+Coarse 3D structure prediction module (Phase 2).
+
+Architecture
+------------
+  sequence encoder  →  CoordHead    →  (B, L, 3)    Cα coordinates
+                    →  FrameHead    →  (B, L, 3, 3) per-residue rotation matrices
+
+The CoordHead predicts absolute Cα positions in an arbitrary global frame.
+The FrameHead predicts a local rotation matrix per residue via Gram-Schmidt
+orthonormalisation of two learned 3-vectors.  Together, (R_i, CA_i) defines the
+backbone frame used by FAPE loss.
+
+FAPE is invariant to the global rotation/translation applied to all predicted
+coordinates, so the model is free to "choose" any global frame during training.
+
+Public API
+----------
+  StructureModule          — full model
+  StructureOutput          — output dataclass
+  build_structure_model()  — factory
+  gram_schmidt_frame()     — standalone utility (also used in losses.py)
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from torch import Tensor
+
+from src.data.protein_dataset import PAD_IDX, VOCAB_SIZE
+from src.models.baseline import BiLSTMModel, ModelKind, SS3_CLASSES, TransformerModel, build_model
+
+
+# ---------------------------------------------------------------------------
+# Gram-Schmidt orthonormalisation
+# ---------------------------------------------------------------------------
+
+def gram_schmidt_frame(a: Tensor, b: Tensor) -> Tensor:
+    """Construct a rotation matrix from two (possibly non-orthogonal) 3-vectors.
+
+    Applies Gram-Schmidt to produce an orthonormal right-handed frame:
+      e1 = normalize(a)
+      e2 = normalize(b - (b·e1) * e1)
+      e3 = cross(e1, e2)
+
+    Args:
+        a: (..., 3) — first direction vector.
+        b: (..., 3) — second direction vector (need not be perpendicular to a).
+
+    Returns:
+        R: (..., 3, 3) rotation matrix whose *columns* are [e1, e2, e3].
+           Satisfies R^T R = I and det(R) = +1 (proper rotation).
+    """
+    e1 = F.normalize(a, dim=-1)                              # (..., 3)
+    e2 = b - (b * e1).sum(dim=-1, keepdim=True) * e1
+    e2 = F.normalize(e2, dim=-1)                             # (..., 3)
+    e3 = torch.cross(e1, e2, dim=-1)                         # (..., 3)
+    return torch.stack([e1, e2, e3], dim=-1)                 # (..., 3, 3)
+
+
+# ---------------------------------------------------------------------------
+# Output dataclass
+# ---------------------------------------------------------------------------
+
+@dataclass
+class StructureOutput:
+    """Output of StructureModule.forward().
+
+    Attributes:
+        ca_coords:  (B, L, 3) float32 — predicted Cα positions.
+        rotations:  (B, L, 3, 3) float32 — per-residue rotation matrices
+                    (None when use_frames=False).
+    """
+    ca_coords: Tensor
+    rotations: Optional[Tensor] = None   # (B, L, 3, 3) or None
+
+    @property
+    def has_frames(self) -> bool:
+        return self.rotations is not None
+
+
+# ---------------------------------------------------------------------------
+# Coordinate head
+# ---------------------------------------------------------------------------
+
+class CoordHead(nn.Module):
+    """Projects per-residue embeddings to Cα coordinates.
+
+    A deliberately simple MLP: LayerNorm → Linear → ReLU → Linear(3).
+    The final layer has no bias so coordinates are initialised near zero,
+    which avoids large initial FAPE loss values.
+
+    Args:
+        hidden_dim: Dimensionality of encoder output.
+        inner_dim:  Hidden size of the intermediate linear layer.
+    """
+
+    def __init__(self, hidden_dim: int, inner_dim: int = 128) -> None:
+        super().__init__()
+        self.net = nn.Sequential(
+            nn.LayerNorm(hidden_dim),
+            nn.Linear(hidden_dim, inner_dim),
+            nn.ReLU(),
+            nn.Linear(inner_dim, 3, bias=False),
+        )
+
+    def forward(self, h: Tensor) -> Tensor:
+        """
+        Args:
+            h: (B, L, hidden_dim)
+        Returns:
+            ca_coords: (B, L, 3)
+        """
+        return self.net(h)
+
+
+# ---------------------------------------------------------------------------
+# Frame head
+# ---------------------------------------------------------------------------
+
+class FrameHead(nn.Module):
+    """Predicts a per-residue rotation matrix from embeddings.
+
+    Projects to 6 raw scalars (two 3-vectors), then applies Gram-Schmidt
+    to obtain a valid rotation matrix.
+
+    Args:
+        hidden_dim: Dimensionality of encoder output.
+    """
+
+    def __init__(self, hidden_dim: int) -> None:
+        super().__init__()
+        self.norm = nn.LayerNorm(hidden_dim)
+        self.proj = nn.Linear(hidden_dim, 6)
+
+    def forward(self, h: Tensor) -> Tensor:
+        """
+        Args:
+            h: (B, L, hidden_dim)
+        Returns:
+            R: (B, L, 3, 3) — per-residue rotation matrices.
+        """
+        x = self.proj(self.norm(h))          # (B, L, 6)
+        a = x[..., :3]                       # (B, L, 3)
+        b = x[..., 3:]                       # (B, L, 3)
+        return gram_schmidt_frame(a, b)      # (B, L, 3, 3)
+
+
+# ---------------------------------------------------------------------------
+# Full structure module
+# ---------------------------------------------------------------------------
+
+class StructureModule(nn.Module):
+    """Encoder + coordinate head + optional frame head.
+
+    Args:
+        encoder:    BiLSTMModel or TransformerModel (its encode() method is used).
+        use_frames: If True, also predict per-residue rotation frames for FAPE.
+        inner_dim:  Hidden dim of the CoordHead MLP.
+    """
+
+    def __init__(
+        self,
+        encoder: BiLSTMModel | TransformerModel,
+        use_frames: bool = True,
+        inner_dim: int = 128,
+    ) -> None:
+        super().__init__()
+        self.encoder = encoder
+        hidden_dim = _encoder_hidden_dim(encoder)
+        self.coord_head = CoordHead(hidden_dim, inner_dim=inner_dim)
+        self.frame_head = FrameHead(hidden_dim) if use_frames else None
+
+    def forward(self, tokens: Tensor) -> StructureOutput:
+        """
+        Args:
+            tokens: (B, L) integer token indices from ProteinDataset.
+        Returns:
+            StructureOutput with .ca_coords (B, L, 3) and
+            .rotations (B, L, 3, 3) if use_frames=True.
+        """
+        h = self.encoder.encode(tokens)                   # (B, L, H)
+        ca_coords = self.coord_head(h)                    # (B, L, 3)
+        rotations = self.frame_head(h) if self.frame_head is not None else None
+        return StructureOutput(ca_coords=ca_coords, rotations=rotations)
+
+    def count_parameters(self) -> int:
+        return sum(p.numel() for p in self.parameters() if p.requires_grad)
+
+    def __repr__(self) -> str:
+        enc = type(self.encoder).__name__
+        frames = self.frame_head is not None
+        return (
+            f"StructureModule(encoder={enc}, frames={frames}, "
+            f"params={self.count_parameters():,})"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Internal helper
+# ---------------------------------------------------------------------------
+
+def _encoder_hidden_dim(encoder: BiLSTMModel | TransformerModel) -> int:
+    if isinstance(encoder, BiLSTMModel):
+        return encoder.lstm.hidden_size * 2
+    if isinstance(encoder, TransformerModel):
+        return encoder.embedding.embedding_dim
+    raise TypeError(f"Unsupported encoder type: {type(encoder)}")
+
+
+# ---------------------------------------------------------------------------
+# Factory
+# ---------------------------------------------------------------------------
+
+def build_structure_model(
+    kind: ModelKind = "bilstm",
+    use_frames: bool = True,
+    **encoder_kwargs,
+) -> StructureModule:
+    """Build a StructureModule with the specified encoder backbone.
+
+    Args:
+        kind:            "bilstm" or "transformer".
+        use_frames:      Whether to predict rotation frames (required for FAPE).
+        **encoder_kwargs: Forwarded to the encoder (e.g. hidden_dim=256).
+
+    Returns:
+        StructureModule ready for training.
+
+    Example::
+
+        model = build_structure_model("bilstm", hidden_dim=256)
+        out = model(tokens)           # StructureOutput
+        ca = out.ca_coords            # (B, L, 3)
+        R  = out.rotations            # (B, L, 3, 3)
+    """
+    encoder = build_model(kind=kind, n_classes=SS3_CLASSES, **encoder_kwargs)
+    return StructureModule(encoder, use_frames=use_frames)

--- a/src/training/losses.py
+++ b/src/training/losses.py
@@ -1,0 +1,166 @@
+"""
+Loss functions for contact map prediction.
+
+All losses accept a boolean mask that identifies valid (i, j) pairs to
+include in the loss computation.  Pairs involving PAD tokens, the diagonal,
+and optionally short-range neighbours (|i-j| < sep_min) should be masked out.
+
+Public API
+----------
+  contact_bce_loss(logits, targets, mask)          — binary cross-entropy
+  focal_loss(logits, targets, mask, gamma, alpha)  — focal loss (class-imbalance)
+  contact_loss(logits, targets, mask, kind, ...)   — dispatcher
+  make_contact_mask(lengths, L, sep_min, device)   — build the valid-pair mask
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+import torch
+import torch.nn.functional as F
+from torch import Tensor
+
+
+# ---------------------------------------------------------------------------
+# Mask builder
+# ---------------------------------------------------------------------------
+
+def make_contact_mask(
+    lengths: Tensor,
+    L: int,
+    sep_min: int = 6,
+    device: torch.device | None = None,
+) -> Tensor:
+    """Build a boolean mask for valid contact pairs in a padded batch.
+
+    A pair (i, j) is valid when:
+      1. Both residues are non-PAD  (i < length_b and j < length_b)
+      2. |i - j| >= sep_min        (exclude trivially local contacts)
+      3. i != j                    (diagonal — implied by sep_min >= 1)
+
+    Args:
+        lengths: (batch,) int tensor — actual sequence length per sample.
+        L:       Padded sequence length (second dim of the logit tensor).
+        sep_min: Minimum sequence separation to include (default 6,
+                 so short-range secondary structure contacts are excluded).
+        device:  Target device; defaults to lengths.device.
+
+    Returns:
+        mask: (batch, L, L) bool tensor — True where the loss should be computed.
+    """
+    if device is None:
+        device = lengths.device
+    B = lengths.size(0)
+
+    # Position indices
+    idx = torch.arange(L, device=device)
+    # Residue-in-sequence mask: (B, L)
+    seq_mask = idx.unsqueeze(0) < lengths.unsqueeze(1)  # (B, L)
+
+    # Pairwise validity: both i and j must be in-sequence
+    pair_mask = seq_mask.unsqueeze(2) & seq_mask.unsqueeze(1)  # (B, L, L)
+
+    # Separation mask: |i - j| >= sep_min
+    sep = (idx.unsqueeze(0) - idx.unsqueeze(1)).abs()           # (L, L)
+    sep_mask = sep.unsqueeze(0) >= sep_min                       # (1, L, L)
+
+    return pair_mask & sep_mask   # (B, L, L)
+
+
+# ---------------------------------------------------------------------------
+# Binary cross-entropy loss
+# ---------------------------------------------------------------------------
+
+def contact_bce_loss(
+    logits: Tensor,
+    targets: Tensor,
+    mask: Tensor,
+) -> Tensor:
+    """Masked binary cross-entropy loss for contact map prediction.
+
+    Args:
+        logits:  (B, L, L) raw logits (pre-sigmoid).
+        targets: (B, L, L) float tensor with values in {0.0, 1.0}.
+        mask:    (B, L, L) bool tensor — True for valid pairs.
+
+    Returns:
+        Scalar mean loss over valid pairs.
+    """
+    if mask.sum() == 0:
+        return logits.sum() * 0.0   # differentiable zero
+
+    loss_per_pair = F.binary_cross_entropy_with_logits(
+        logits, targets.float(), reduction="none"
+    )                                              # (B, L, L)
+    return loss_per_pair[mask].mean()
+
+
+# ---------------------------------------------------------------------------
+# Focal loss
+# ---------------------------------------------------------------------------
+
+def focal_loss(
+    logits: Tensor,
+    targets: Tensor,
+    mask: Tensor,
+    gamma: float = 2.0,
+    alpha: float = 0.25,
+) -> Tensor:
+    """Masked focal loss for class-imbalanced contact prediction.
+
+    Contact maps are sparse (~5% positive pairs), so focal loss down-weights
+    easy negatives and focuses training on hard examples.
+
+    Args:
+        logits:  (B, L, L) raw logits.
+        targets: (B, L, L) float tensor in {0.0, 1.0}.
+        mask:    (B, L, L) bool — valid pairs.
+        gamma:   Focusing parameter (default 2.0).
+        alpha:   Weighting for positive class (default 0.25).
+
+    Returns:
+        Scalar mean focal loss over valid pairs.
+    """
+    if mask.sum() == 0:
+        return logits.sum() * 0.0
+
+    targets_f = targets.float()
+    bce = F.binary_cross_entropy_with_logits(logits, targets_f, reduction="none")
+    p_t = torch.exp(-bce)                        # probability of correct class
+    alpha_t = alpha * targets_f + (1 - alpha) * (1 - targets_f)
+    loss_per_pair = alpha_t * (1 - p_t) ** gamma * bce
+    return loss_per_pair[mask].mean()
+
+
+# ---------------------------------------------------------------------------
+# Dispatcher
+# ---------------------------------------------------------------------------
+
+LossKind = Literal["bce", "focal"]
+
+
+def contact_loss(
+    logits: Tensor,
+    targets: Tensor,
+    mask: Tensor,
+    kind: LossKind = "bce",
+    **kwargs,
+) -> Tensor:
+    """Compute contact map loss by name.
+
+    Args:
+        logits:   (B, L, L) raw logits.
+        targets:  (B, L, L) float tensor in {0.0, 1.0}.
+        mask:     (B, L, L) bool — valid pairs.
+        kind:     "bce" or "focal".
+        **kwargs: Forwarded to the chosen loss (e.g. gamma=2.0 for focal).
+
+    Returns:
+        Scalar loss.
+    """
+    if kind == "bce":
+        return contact_bce_loss(logits, targets, mask)
+    if kind == "focal":
+        return focal_loss(logits, targets, mask, **kwargs)
+    raise ValueError(f"Unknown loss kind {kind!r}. Choose 'bce' or 'focal'.")

--- a/src/training/losses.py
+++ b/src/training/losses.py
@@ -1,16 +1,18 @@
 """
-Loss functions for contact map prediction.
+Loss functions for structure prediction and contact map prediction.
 
-All losses accept a boolean mask that identifies valid (i, j) pairs to
-include in the loss computation.  Pairs involving PAD tokens, the diagonal,
-and optionally short-range neighbours (|i-j| < sep_min) should be masked out.
-
-Public API
-----------
+Contact map losses
+------------------
   contact_bce_loss(logits, targets, mask)          — binary cross-entropy
   focal_loss(logits, targets, mask, gamma, alpha)  — focal loss (class-imbalance)
   contact_loss(logits, targets, mask, kind, ...)   — dispatcher
   make_contact_mask(lengths, L, sep_min, device)   — build the valid-pair mask
+
+Structure losses (Phase 2)
+--------------------------
+  make_backbone_frames(backbone_coords)            — true frames from N/CA/C atoms
+  fape_loss(pred_t, true_t, pred_R, true_R, mask)  — Frame-Aligned Point Error
+  backbone_rmsd(pred_ca, true_ca, mask)            — per-batch RMSD (no alignment)
 """
 
 from __future__ import annotations
@@ -20,6 +22,7 @@ from typing import Literal
 import torch
 import torch.nn.functional as F
 from torch import Tensor
+
 
 
 # ---------------------------------------------------------------------------
@@ -164,3 +167,139 @@ def contact_loss(
     if kind == "focal":
         return focal_loss(logits, targets, mask, **kwargs)
     raise ValueError(f"Unknown loss kind {kind!r}. Choose 'bce' or 'focal'.")
+
+
+# ===========================================================================
+# Structure losses (Phase 2)
+# ===========================================================================
+
+# Atom indices in backbone_coords tensor (matches pdb_parser.BACKBONE_ATOMS)
+_N_IDX, _CA_IDX, _C_IDX = 0, 1, 2
+
+
+def make_backbone_frames(
+    backbone_coords: Tensor,
+) -> tuple[Tensor, Tensor]:
+    """Construct local backbone frames from N, Cα, C atom positions.
+
+    The local frame for residue i is defined by:
+      e1 = normalize(N_i  − Cα_i)        — points from Cα toward N
+      e3 = normalize(e1 × (C_i − Cα_i))  — normal to the backbone plane
+      e2 = e3 × e1                        — completes the right-handed frame
+      t  = Cα_i                           — origin is Cα
+
+    This convention matches the AF2 backbone frame (Jumper et al. Suppl. §1.8).
+
+    Args:
+        backbone_coords: (..., L, 4, 3) float32 — atom order [N, CA, C, O].
+                         Leading dimensions may be batch dims.
+
+    Returns:
+        rotations:    (..., L, 3, 3) — rotation matrix, columns = [e1, e2, e3].
+        translations: (..., L, 3)   — Cα positions.
+    """
+    N  = backbone_coords[..., _N_IDX,  :]   # (..., L, 3)
+    CA = backbone_coords[..., _CA_IDX, :]   # (..., L, 3)
+    C  = backbone_coords[..., _C_IDX,  :]   # (..., L, 3)
+
+    v1 = N - CA                                       # N → Cα direction
+    v2 = C - CA                                       # Cα → C direction
+
+    e1 = F.normalize(v1, dim=-1)
+    e3 = F.normalize(torch.cross(e1, v2, dim=-1), dim=-1)
+    e2 = torch.cross(e3, e1, dim=-1)
+
+    rotations = torch.stack([e1, e2, e3], dim=-1)    # (..., L, 3, 3) columns
+    return rotations, CA
+
+
+def fape_loss(
+    pred_t: Tensor,
+    true_t: Tensor,
+    pred_R: Tensor,
+    true_R: Tensor,
+    seq_mask: Tensor,
+    d_clamp: float = 10.0,
+    eps: float = 1e-6,
+    z: float = 10.0,
+) -> Tensor:
+    """Frame-Aligned Point Error (FAPE) loss.
+
+    For each residue i (the "frame"), transform all Cα positions j into
+    residue i's local coordinate system — in both prediction and ground truth —
+    then measure the distance between the two transformed points.
+
+    FAPE_i = (1/L) * Σ_j  clamp(||R_i^T(x_j−t_i) − R_i^{*T}(x_j^*−t_i^*)||, d_clamp)
+
+    Averaged over all valid frames i and points j, then divided by z (the
+    AF2 normalisation constant, default 10 Å) to give dimensionless loss values.
+
+    FAPE is invariant to global rotation and translation of the predicted
+    structure (as long as pred_R transforms consistently with pred_t).
+
+    Args:
+        pred_t:   (B, L, 3) — predicted Cα positions.
+        true_t:   (B, L, 3) — true Cα positions.
+        pred_R:   (B, L, 3, 3) — predicted rotation matrices.
+        true_R:   (B, L, 3, 3) — true rotation matrices (from make_backbone_frames).
+        seq_mask: (B, L) bool — True for non-PAD residues.
+        d_clamp:  Maximum per-pair error contributing to the loss (Å).
+        eps:      Small constant added before sqrt for numerical stability.
+        z:        Normalisation constant (default 10 Å, as in AF2).
+
+    Returns:
+        Scalar FAPE loss.
+    """
+    # --- transform all points j into each frame i ---
+    # diff[b, i, j, :] = t_j − t_i    (B, L_frame, L_point, 3)
+    diff_pred = pred_t.unsqueeze(2) - pred_t.unsqueeze(1)   # (B, L, L, 3)
+    diff_true = true_t.unsqueeze(2) - true_t.unsqueeze(1)   # (B, L, L, 3)
+
+    # Apply R_i^T to each diff vector:
+    # local[b,i,j,k] = Σ_m R[b,i,m,k] * diff[b,i,j,m]   (R^T = R transposed on last 2 dims)
+    local_pred = torch.einsum("bimk,bijm->bijk", pred_R, diff_pred)  # (B, L, L, 3)
+    local_true = torch.einsum("bimk,bijm->bijk", true_R, diff_true)  # (B, L, L, 3)
+
+    # Per-pair distance error (with numerical stabilisation)
+    sq_err = (local_pred - local_true).pow(2).sum(dim=-1)    # (B, L, L)
+    err = torch.sqrt(sq_err + eps)                           # (B, L, L)
+    clamped = torch.clamp(err, max=d_clamp)                  # (B, L, L)
+
+    # Valid-pair mask: both frame i and point j must be non-PAD
+    pair_mask = seq_mask.unsqueeze(2) & seq_mask.unsqueeze(1)  # (B, L, L)
+
+    if pair_mask.sum() == 0:
+        return pred_t.sum() * 0.0   # differentiable zero
+
+    return clamped[pair_mask].mean() / z
+
+
+def backbone_rmsd(
+    pred_ca: Tensor,
+    true_ca: Tensor,
+    seq_mask: Tensor,
+) -> Tensor:
+    """Per-sample Cα RMSD, averaged over the batch.
+
+    Note: this is *unaligned* RMSD — use Kabsch alignment in evaluation code
+    for a meaningful structural metric.  During training, FAPE is preferred.
+
+    Args:
+        pred_ca:  (B, L, 3)
+        true_ca:  (B, L, 3)
+        seq_mask: (B, L) bool
+
+    Returns:
+        Scalar mean RMSD (Å) over the batch.
+    """
+    sq = (pred_ca - true_ca).pow(2).sum(dim=-1)   # (B, L)
+    rmsds = []
+    for b in range(pred_ca.size(0)):
+        m = seq_mask[b]
+        if m.sum() > 0:
+            rmsds.append(sq[b][m].mean().sqrt())
+    if not rmsds:
+        return pred_ca.sum() * 0.0
+    return torch.stack(rmsds).mean()
+
+


### PR DESCRIPTION
## Summary

- **`src/models/structure_module.py`**: `StructureModule` wraps any sequence encoder with a `CoordHead` (predicts Cα positions) and `FrameHead` (predicts per-residue rotation matrices via Gram-Schmidt orthonormalisation). `StructureOutput` dataclass carries `ca_coords (B,L,3)` + `rotations (B,L,3,3)`.
- **`src/training/losses.py`**: Extended with `make_backbone_frames` (constructs true SE(3) frames from N/Cα/C), `fape_loss` (vectorised FAPE with einsum, clamping, and AF2 normalisation constant z=10 Å), and `backbone_rmsd` (unaligned per-sample RMSD).
- **`scripts/train_structure.py`**: Full training pipeline — synthetic helix dataset for quick smoke-tests, real PDB download path, `kabsch_align` for SVD-based superposition with reflection correction, `tm_score` and `gdt_ts` evaluation metrics computed each epoch.

## Test plan

- [x] Synthetic path: `python scripts/train_structure.py --epochs 3` — FAPE decreases, TM-score > 0.05
- [x] Real PDB path: `python scripts/train_structure.py --pdb-ids 1UBQ,1CRN --epochs 3 --batch-size 2` — runs without error, metrics reported
- [ ] Unit tests for `fape_loss`, `make_backbone_frames`, `gram_schmidt_frame` (deferred to `tests/` milestone)

🤖 Generated with [Claude Code](https://claude.com/claude-code)