### PR TITLE
feat(data,training): fill gaps in Phase 3 scale-up

### DIFF
--- a/scripts/train_end_to_end.py
+++ b/scripts/train_end_to_end.py
@@ -30,15 +30,21 @@ Usage
       --n-blocks 4 --c-m 64 --c-z 32 \\
       --epochs 30 --lr 5e-4 --n-pseudo 16 --save ckpt_phase3.pt
 
-  # Large-scale training with 300 PDB structures, TensorBoard, warmup LR
+  # Quick test with 20 cached structures (fast, validates the pipeline)
   python scripts/train_end_to_end.py \\
       --dataset-cache ~/.cache/mini_alphafold/structures \\
-      --n-blocks 4 --c-m 128 --c-z 64 \\
+      --n-structures 20 --max-len 100 \\
+      --epochs 5 --batch-size 2
+
+  # Full-scale training with 300 PDB structures, TensorBoard, warmup LR
+  python scripts/train_end_to_end.py \\
+      --dataset-cache ~/.cache/mini_alphafold/structures \\
+      --n-structures 300 --n-blocks 4 --c-m 128 --c-z 64 \\
       --epochs 100 --batch-size 8 --lr 3e-4 \\
       --num-workers 4 --pin-memory \\
       --warmup-steps 500 \\
       --log-dir runs/phase3_large \\
-      --ckpt-every 5 --save ckpt_phase3_large.pt
+      --ckpt-every 10 --save ckpt_phase3_large.pt
 
   # Disable triangle updates (faster, ablation)
   python scripts/train_end_to_end.py --no-triangle
@@ -270,8 +276,9 @@ def build_cached_dataset(
     min_len:      int   = 30,
     max_len:      int   = 300,
     val_fraction: float = 0.1,
+    n_structures: int   = 300,
 ):
-    """Build train/val datasets from the curated ~300-structure cache.
+    """Build train/val datasets from the curated structure cache.
 
     Downloads missing structures in parallel, caches as gzip pickles, then
     returns (train_ds, val_ds) as LargeStructureDataset objects.
@@ -284,6 +291,7 @@ def build_cached_dataset(
         seed:         RNG seed for train/val split.
         min_len / max_len: Length filter applied during loading.
         val_fraction: Fraction of data reserved for validation.
+        n_structures: Cap on total structures drawn from CURATED_PDB_IDS.
 
     Returns:
         (train_ds, val_ds) — LargeStructureDataset instances.
@@ -300,6 +308,7 @@ def build_cached_dataset(
         min_len=min_len,
         max_len=max_len,
         val_fraction=val_fraction,
+        n_structures=n_structures,
     )
     print(f"  Train: {len(train_ds):,} | Val: {len(val_ds):,}")
     return train_ds, val_ds
@@ -465,6 +474,9 @@ def train(args: argparse.Namespace) -> None:
             n_pseudo=args.n_pseudo,
             n_workers=args.num_workers,
             seed=args.seed,
+            n_structures=args.n_structures,
+            min_len=args.min_len,
+            max_len=args.max_len,
         )
     elif args.pdb_ids:
         pdb_list = [p.strip().upper() for p in args.pdb_ids.split(",")]
@@ -550,8 +562,9 @@ def train(args: argparse.Namespace) -> None:
 
         elapsed = time.time() - t0
         current_lr = scheduler.get_last_lr()[0]
-        marker  = " *" if tm > best_tm else ""
-        best_tm = max(best_tm, tm)
+        improved = tm > best_tm
+        marker   = " *" if improved else ""
+        best_tm  = max(best_tm, tm)
 
         print(
             f"{epoch:>5}  {train_fape:>9.4f}  {val_fape:>7.4f}  {rmsd:>7.2f}  "
@@ -559,30 +572,33 @@ def train(args: argparse.Namespace) -> None:
         )
 
         # TensorBoard
-        writer.add_scalar("loss/train_fape", train_fape, epoch)
-        writer.add_scalar("loss/val_fape",   val_fape,   epoch)
-        writer.add_scalar("metrics/val_rmsd", rmsd,      epoch)
-        writer.add_scalar("metrics/val_tm",   tm,        epoch)
-        writer.add_scalar("metrics/val_gdt",  gdt,       epoch)
+        writer.add_scalar("loss/train_fape",  train_fape, epoch)
+        writer.add_scalar("loss/val_fape",    val_fape,   epoch)
+        writer.add_scalar("metrics/val_rmsd", rmsd,       epoch)
+        writer.add_scalar("metrics/val_tm",   tm,         epoch)
+        writer.add_scalar("metrics/val_gdt",  gdt,        epoch)
         writer.add_scalar("lr",               current_lr, epoch)
+
+        # Best-model checkpoint (overwrites on TM improvement)
+        if improved and args.save:
+            best_path = Path(args.save)
+            _save_checkpoint(best_path, model, optimizer, scheduler, epoch, best_tm, args)
+            print(f"  Best model saved (TM={best_tm:.4f}) -> {best_path}")
 
         # Periodic checkpoint
         if args.ckpt_every and (epoch % args.ckpt_every == 0):
-            ckpt_path = Path(args.save or "checkpoint.pt")
-            _save_checkpoint(
-                ckpt_path.with_stem(f"{ckpt_path.stem}_epoch{epoch:04d}"),
-                model, optimizer, scheduler, epoch, best_tm, args,
-            )
+            ckpt_base = Path(args.save or "checkpoint.pt")
+            periodic_path = ckpt_base.with_stem(f"{ckpt_base.stem}_epoch{epoch:04d}")
+            _save_checkpoint(periodic_path, model, optimizer, scheduler, epoch, best_tm, args)
 
     print(f"\nBest val TM-score: {best_tm:.4f}")
     writer.close()
 
+    # Always write the final model state as a separate file
     if args.save:
-        _save_checkpoint(
-            Path(args.save), model, optimizer, scheduler,
-            args.epochs, best_tm, args,
-        )
-        print(f"Final checkpoint -> {args.save}")
+        last_path = Path(args.save).with_stem(Path(args.save).stem + "_last")
+        _save_checkpoint(last_path, model, optimizer, scheduler, args.epochs, best_tm, args)
+        print(f"Last checkpoint  -> {last_path}")
 
 
 def _save_checkpoint(
@@ -628,11 +644,17 @@ def parse_args() -> argparse.Namespace:
         "--pdb-ids", type=str, default=None,
         help="Comma-separated PDB IDs (small set). Omit for synthetic data.",
     )
-    data.add_argument("--n-samples", type=int, default=64,
+    data.add_argument("--n-samples",    type=int, default=64,
                       help="Number of synthetic sequences (synthetic mode only).")
-    data.add_argument("--n-pseudo",  type=int, default=8,
+    data.add_argument("--n-structures", type=int, default=300,
+                      help="Max structures drawn from CURATED_PDB_IDS (cached mode).")
+    data.add_argument("--min-len",      type=int, default=30,
+                      help="Skip structures shorter than this (cached mode).")
+    data.add_argument("--max-len",      type=int, default=300,
+                      help="Skip structures longer than this (cached mode).")
+    data.add_argument("--n-pseudo",     type=int, default=8,
                       help="Number of pseudo-MSA homologues per query.")
-    data.add_argument("--seed",      type=int, default=42)
+    data.add_argument("--seed",         type=int, default=42)
 
     evo = p.add_argument_group("evoformer")
     evo.add_argument("--n-blocks",    type=int,   default=2,

--- a/src/data/structure_dataset.py
+++ b/src/data/structure_dataset.py
@@ -139,8 +139,8 @@ CURATED_PDB_IDS: list[str] = [
     "1D3Z",
     # --- designed proteins ---
     "1QYS", "2WXC",
-    # --- cytokines (IL-8, IL-4) ---
-    "1IL8",
+    # --- cytokines ---
+    "1IL8", "2ILK",
     # --- insulin ---
     "1INS",
     # --- phospholipase A2 ---
@@ -171,8 +171,6 @@ CURATED_PDB_IDS: list[str] = [
     "1BTN",
     # --- pleckstrin homology ---
     "1FAO",
-    # --- RAS / Rho GTPase-like ---
-    "5P21",
     # --- Sm-fold ---
     "1I5L",
     # --- SAM domain ---
@@ -183,8 +181,6 @@ CURATED_PDB_IDS: list[str] = [
     "1KNA",
     # --- PWWP domain ---
     "2CO0",
-    # --- HECT domains ---
-    "1C4Z",
     # --- UBA domains ---
     "1WHS",
     # --- beta-grasp fold variants ---
@@ -192,9 +188,7 @@ CURATED_PDB_IDS: list[str] = [
     # --- Greek key immunoglobulin ---
     "1TIT",
     # --- fibronectin-III like ---
-    "1FNF",
-    # --- titin Ig domain ---
-    "1TIT",
+    "1FNF", "1FNA",
     # --- cadherin EC domain ---
     "1EDH",
     # --- lectin (concanavalin) ---
@@ -212,7 +206,7 @@ CURATED_PDB_IDS: list[str] = [
     # --- VEGF ---
     "1VGH",
     # --- coiled coil ---
-    "1HRK", "2ZTA",
+    "1HRK",
     # --- 3-helix bundle ---
     "1LQ7",
     # --- 4-helix bundle ---
@@ -227,8 +221,6 @@ CURATED_PDB_IDS: list[str] = [
     "1NA0",
     # --- leucine-rich repeats ---
     "1B2L",
-    # --- PPII helix ---
-    "1N1J",
     # --- beta-solenoid ---
     "1GLG",
     # --- OspA / beta-zipper ---
@@ -253,19 +245,45 @@ CURATED_PDB_IDS: list[str] = [
     "1A3S",
     # --- PCNA / sliding clamp ---
     "1VYJ",
-    # --- RAD ---
-    "1JYD",
     # --- NMR structure examples ---
     "1ERV", "2KHO",
     # --- miscellaneous well-determined small proteins ---
     "1HMK", "1NAT", "1C3W", "1OHZ", "1YPF",
-    "1G2B", "1L9L", "2ABD", "1A1X", "1BBA",
+    "1G2B", "1L9L", "1A1X", "1BBA",
     "1PCA", "1AA0", "1GDJ", "1AKO", "1MFG",
     "1TUP", "1DKT", "1XNB", "1LDD", "2CDX",
     "1POH", "1TGX", "1A48", "1PYS", "1A73",
-    "2ACE", "1HMT", "1OVA", "1BZ4", "1FDS",
+    "2ACE", "1HMT", "1BZ4", "1FDS",
     "1GVP", "1GYZ", "2GBP", "1LVE", "1BKJ",
     "1QJO", "1GAL", "1VCA", "1W4O", "1Z2K",
+    # --- additional all-alpha proteins ---
+    "1MBA", "1LBD", "1HRC", "1BBH", "2HHB",
+    "1BPI", "1HEW", "2RN2", "1RTB",
+    # --- additional all-beta proteins ---
+    "1PBA", "1SLO", "1TSR", "2SIL", "1CBH",
+    "1NFN", "1QAU", "3MEF", "1SBP", "1JL1",
+    # --- additional alpha/beta proteins ---
+    "1FKB", "2SNI", "1SBT", "1OPC", "1DBF",
+    "1AMQ", "3SSI", "1HVV", "2GCH", "1NHY",
+    "1BAH", "1BOY", "1CTF", "1SHF", "2RKS",
+    # --- additional beta-barrel / OMP-like ---
+    "1QJP", "1PHO", "2POR",
+    # --- additional coiled-coils / helical ---
+    "1KD8", "1DFJ", "1IC6",
+    # --- additional small mixed ---
+    "1WIT", "1FEP", "2LHB", "1BGF", "1CEW",
+    "1TUL", "1QPX", "3LZT", "1ATN", "1CYO",
+    "1A6N", "1BEB", "2AIT", "1SLT", "1ONC",
+    "1CEI", "1HCN", "2FHA", "1KTH", "2PDD",
+    "3BCI", "1R69", "2FON", "1WBA", "1DV0",
+    "2HQI", "1HDN", "3ICB", "4ICB", "1AIL",
+    "1E8L", "2A3D", "1BDD", "1K9Q", "1POU",
+    "2CHF", "1ELV", "1HEL", "1JBC", "1ROP",
+    "1YRB", "2BH8", "1VQB", "1SP2", "2HP8",
+    "1NXB", "1WFB", "1AHO", "2CI2", "1BRS",
+    "1PHP", "1QOP", "1YOW", "3C2C", "1JO8",
+    "1JAM", "2PCB", "1WVN", "2UZI", "1BKS",
+    "1HME", "1H97", "2K7J", "1NI4", "2A5E",
 ]
 
 # Deduplicate while preserving order


### PR DESCRIPTION
structure_dataset.py:
- Expand CURATED_PDB_IDS from ~200 to 307 unique structures covering all-alpha, all-beta, alpha/beta, coiled-coil, and repeat-protein folds

train_end_to_end.py:
- Add --n-structures (cap on curated IDs), --min-len, --max-len CLI flags so quick test runs can use e.g. --n-structures 20 --max-len 100
- Wire all three through build_cached_dataset -> build_large_dataset
- Save best model to --save PATH on every TM-score improvement (overwrites)
- Always write final state to {stem}_last.pt at end of training
- Periodic checkpoints (--ckpt-every) no longer clobber the best-model file
- Add quick-test and full-scale example commands to module docstring