### PR TITLE
[Infra] Add experiment configs for training scripts

### DIFF
--- a/configs/baseline.yaml
+++ b/configs/baseline.yaml
@@ -1,0 +1,14 @@
+data:
+  real_data: false
+  ss_type: ss3
+  max_samples: null
+  n_samples: 512
+
+model:
+  model: bilstm
+
+training:
+  epochs: 10
+  batch_size: 16
+  lr: 1.0e-3
+  save: null

--- a/configs/contact.yaml
+++ b/configs/contact.yaml
@@ -1,0 +1,16 @@
+data:
+  pdb_ids: null
+  n_samples: 256
+  threshold: 8.0
+  sep_min: 6
+
+model:
+  model: bilstm
+  pair_dim: 64
+  loss: bce
+
+training:
+  epochs: 10
+  batch_size: 4
+  lr: 1.0e-3
+  save: null

--- a/configs/end_to_end.yaml
+++ b/configs/end_to_end.yaml
@@ -1,0 +1,27 @@
+data:
+  dataset_cache: null
+  pdb_ids: null
+  n_samples: 64
+  n_structures: 300
+  min_len: 30
+  max_len: 300
+  n_pseudo: 8
+  seed: 42
+
+evoformer:
+  n_blocks: 2
+  c_m: 64
+  c_z: 32
+  no_triangle: false
+
+training:
+  epochs: 10
+  batch_size: 4
+  lr: 1.0e-3
+  d_clamp: 10.0
+  warmup_steps: 0
+  num_workers: 0
+  pin_memory: false
+  log_dir: null
+  ckpt_every: 0
+  save: null

--- a/configs/structure.yaml
+++ b/configs/structure.yaml
@@ -1,0 +1,13 @@
+data:
+  pdb_ids: null
+  n_samples: 128
+
+model:
+  model: bilstm
+
+training:
+  epochs: 10
+  batch_size: 4
+  lr: 1.0e-3
+  d_clamp: 10.0
+  save: null

--- a/scripts/train_baseline.py
+++ b/scripts/train_baseline.py
@@ -33,6 +33,8 @@ import sys
 import time
 from pathlib import Path
 
+import yaml
+
 import torch
 import torch.nn as nn
 from torch import Tensor
@@ -232,10 +234,36 @@ def train(args: argparse.Namespace) -> None:
 # CLI
 # ---------------------------------------------------------------------------
 
+def _load_config(path: str) -> dict:
+    """Load a YAML config file and return a flat dict of key -> value.
+
+    Nested sections (data, model, training) are flattened by replacing
+    hyphens with underscores so they align with argparse dest names.
+    """
+    with open(path) as f:
+        cfg = yaml.safe_load(f) or {}
+    flat: dict = {}
+    for section in cfg.values():
+        if isinstance(section, dict):
+            for k, v in section.items():
+                flat[k.replace("-", "_")] = v
+    return flat
+
+
 def parse_args() -> argparse.Namespace:
+    # Pre-scan for --config before building the full parser so we can load
+    # YAML defaults before argparse sets its own defaults.
+    pre = argparse.ArgumentParser(add_help=False)
+    pre.add_argument("--config", type=str, default=None)
+    pre_ns, _ = pre.parse_known_args()
+
     p = argparse.ArgumentParser(
         description="Train baseline secondary structure model",
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    p.add_argument(
+        "--config", type=str, default=None,
+        help="Path to YAML experiment config (CLI args override config values).",
     )
 
     # Data
@@ -273,6 +301,10 @@ def parse_args() -> argparse.Namespace:
         "--save", type=str, default=None,
         help="Path to save checkpoint, e.g. checkpoints/baseline.pt",
     )
+
+    # Apply YAML defaults (CLI args will still override these)
+    if pre_ns.config:
+        p.set_defaults(**_load_config(pre_ns.config))
 
     return p.parse_args()
 

--- a/scripts/train_contact.py
+++ b/scripts/train_contact.py
@@ -46,6 +46,8 @@ import urllib.request
 from pathlib import Path
 from typing import Optional
 
+import yaml
+
 import torch
 import torch.nn as nn
 from torch import Tensor
@@ -470,10 +472,30 @@ def train(args: argparse.Namespace) -> None:
 # CLI
 # ---------------------------------------------------------------------------
 
+def _load_config(path: str) -> dict:
+    """Load a YAML config and return a flat dict aligned with argparse dest names."""
+    with open(path) as f:
+        cfg = yaml.safe_load(f) or {}
+    flat: dict = {}
+    for section in cfg.values():
+        if isinstance(section, dict):
+            for k, v in section.items():
+                flat[k.replace("-", "_")] = v
+    return flat
+
+
 def parse_args() -> argparse.Namespace:
+    pre = argparse.ArgumentParser(add_help=False)
+    pre.add_argument("--config", type=str, default=None)
+    pre_ns, _ = pre.parse_known_args()
+
     p = argparse.ArgumentParser(
         description="Train contact map predictor",
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    p.add_argument(
+        "--config", type=str, default=None,
+        help="Path to YAML experiment config (CLI args override config values).",
     )
 
     data = p.add_argument_group("data")
@@ -500,6 +522,9 @@ def parse_args() -> argparse.Namespace:
     train_g.add_argument("--batch-size", type=int,   default=4)
     train_g.add_argument("--lr",         type=float, default=1e-3)
     train_g.add_argument("--save",       type=str,   default=None)
+
+    if pre_ns.config:
+        p.set_defaults(**_load_config(pre_ns.config))
 
     return p.parse_args()
 

--- a/scripts/train_end_to_end.py
+++ b/scripts/train_end_to_end.py
@@ -64,6 +64,7 @@ import urllib.request
 from pathlib import Path
 from typing import Optional
 
+import yaml
 import torch
 import torch.nn as nn
 from torch import Tensor
@@ -629,10 +630,30 @@ def _save_checkpoint(
 # CLI
 # ---------------------------------------------------------------------------
 
+def _load_config(path: str) -> dict:
+    """Load a YAML config and return a flat dict aligned with argparse dest names."""
+    with open(path) as f:
+        cfg = yaml.safe_load(f) or {}
+    flat: dict = {}
+    for section in cfg.values():
+        if isinstance(section, dict):
+            for k, v in section.items():
+                flat[k.replace("-", "_")] = v
+    return flat
+
+
 def parse_args() -> argparse.Namespace:
+    pre = argparse.ArgumentParser(add_help=False)
+    pre.add_argument("--config", type=str, default=None)
+    pre_ns, _ = pre.parse_known_args()
+
     p = argparse.ArgumentParser(
         description="End-to-end MSA-aware structure prediction (Phase 3)",
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    p.add_argument(
+        "--config", type=str, default=None,
+        help="Path to YAML experiment config (CLI args override config values).",
     )
 
     data = p.add_argument_group("data")
@@ -684,6 +705,9 @@ def parse_args() -> argparse.Namespace:
                          help="Save a checkpoint every N epochs (0 = disabled).")
     train_g.add_argument("--save",         type=str,   default=None,
                          help="Path to save final checkpoint (.pt).")
+
+    if pre_ns.config:
+        p.set_defaults(**_load_config(pre_ns.config))
 
     return p.parse_args()
 

--- a/scripts/train_structure.py
+++ b/scripts/train_structure.py
@@ -41,6 +41,7 @@ import urllib.request
 from pathlib import Path
 from typing import Optional
 
+import yaml
 import torch
 import torch.nn as nn
 from torch import Tensor
@@ -413,11 +414,32 @@ def train(args: argparse.Namespace) -> None:
 # CLI
 # ---------------------------------------------------------------------------
 
+def _load_config(path: str) -> dict:
+    """Load a YAML config and return a flat dict aligned with argparse dest names."""
+    with open(path) as f:
+        cfg = yaml.safe_load(f) or {}
+    flat: dict = {}
+    for section in cfg.values():
+        if isinstance(section, dict):
+            for k, v in section.items():
+                flat[k.replace("-", "_")] = v
+    return flat
+
+
 def parse_args() -> argparse.Namespace:
+    pre = argparse.ArgumentParser(add_help=False)
+    pre.add_argument("--config", type=str, default=None)
+    pre_ns, _ = pre.parse_known_args()
+
     p = argparse.ArgumentParser(
         description="Train coarse 3D structure predictor (Phase 2)",
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     )
+    p.add_argument(
+        "--config", type=str, default=None,
+        help="Path to YAML experiment config (CLI args override config values).",
+    )
+
     data = p.add_argument_group("data")
     data.add_argument(
         "--pdb-ids", type=str, default=None,
@@ -435,6 +457,9 @@ def parse_args() -> argparse.Namespace:
     train_g.add_argument("--d-clamp",    type=float, default=10.0,
                          help="FAPE clamping distance in Angstroms")
     train_g.add_argument("--save",       type=str,   default=None)
+
+    if pre_ns.config:
+        p.set_defaults(**_load_config(pre_ns.config))
 
     return p.parse_args()
 


### PR DESCRIPTION
## Summary
Adds YAML experiment configs for all 4 training scripts and wires in a --config flag so hyperparameters can be set without editing source.

## What Changed
- `configs/baseline.yaml`, `configs/contact.yaml`, `configs/structure.yaml`, `configs/end_to_end.yaml` — each captures all hyperparameters currently hardcoded in the corresponding training script
- All 4 training scripts updated with `_load_config()` helper and `--config path/to/config.yaml` argparse argument; YAML sets defaults, CLI args still override; backward compatible (works without --config)
- PyYAML was already in requirements.txt; no new dependency

## Reviewer Notes
The `_load_config()` helper flattens nested YAML keys into a flat dict before calling `parser.set_defaults()`, which matches argparse's flat namespace. CLI overrides work correctly.

## Test Plan
- [ ] `python scripts/train_baseline.py` still works without --config
- [ ] `python scripts/train_baseline.py --config configs/baseline.yaml` loads YAML values
- [ ] CLI `--lr 1e-4` overrides YAML value when both are provided