### PR TITLE
[Infra] Add project-specific .gitignore entries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,15 @@
+# mini-alphafold: project-specific ignores
+*.pt
+*.pth
+*.ckpt
+*.pdb
+*.cif
+*.mmcif
+runs/
+wandb/
+mlruns/
+data/
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[codz]


### PR DESCRIPTION
## Summary
Adds mini-alphafold-specific entries to the existing .gitignore so checkpoints, PDB files, and training run directories are never accidentally committed.

## What Changed
- Added entries for: \`*.pt\`, \`*.pth\`, \`*.ckpt\`, \`*.pdb\`, \`*.cif\`, \`runs/\`, \`wandb/\`, \`mlruns/\`, \`data/\`

## Reviewer Notes
No production code changed. The existing generic Python gitignore was already present; this prepends project-specific entries.

## Test Plan
- [ ] \`git status\` does not surface \`ckpt_phase3.pt\`, \`1UBQ.pdb\`, or \`runs/\` as untracked