### PR TITLE
[Test] Unit tests for data parsing and collation

### DIFF
--- a/tests/data/test_loaders.py
+++ b/tests/data/test_loaders.py
@@ -1,0 +1,128 @@
+"""Tests for src/data/loaders.py — collation and MSADataset."""
+
+import torch
+import pytest
+from torch.utils.data import DataLoader
+
+from src.data.loaders import (
+    collate_fn,
+    MSADataset,
+    collate_msa_fn,
+    SS3_LABEL_MAP,
+    SS8_LABEL_MAP,
+)
+from src.data.protein_dataset import PAD_IDX, ProteinDataset
+
+
+# ---------------------------------------------------------------------------
+# collate_fn (sequence + label batching)
+# ---------------------------------------------------------------------------
+
+def _make_batch(seqs, labels=None):
+    """Helper: build a batch list as collate_fn expects."""
+    from src.data.protein_dataset import tokenize
+    if labels is None:
+        return [(tokenize(s),) for s in seqs]
+    return [(tokenize(s), lab) for s, lab in zip(seqs, labels)]
+
+
+def test_collate_fn_pads_tokens():
+    """collate_fn pads token tensors to the longest sequence in the batch."""
+    from src.data.protein_dataset import tokenize
+    batch = [
+        (tokenize("ACF"), torch.zeros(3, dtype=torch.long)),
+        (tokenize("GHIKL"), torch.zeros(5, dtype=torch.long)),
+    ]
+    tokens, labels = collate_fn(batch)
+    assert tokens.shape == (2, 5)                      # padded to max len 5
+    assert tokens[0, 3].item() == PAD_IDX              # short seq padded at end
+    assert tokens[0, 4].item() == PAD_IDX
+
+
+def test_collate_fn_token_dtype():
+    """Collated token tensor should be long (int64)."""
+    from src.data.protein_dataset import tokenize
+    batch = [(tokenize("ACDEF"), torch.zeros(5, dtype=torch.long))]
+    tokens, _ = collate_fn(batch)
+    assert tokens.dtype == torch.long
+
+
+def test_collate_fn_label_padding():
+    """Labels are padded to max length with -1 (CrossEntropyLoss ignore_index)."""
+    from src.data.protein_dataset import tokenize
+    batch = [
+        (tokenize("AC"), torch.tensor([0, 1])),
+        (tokenize("GHIKL"), torch.tensor([2, 0, 1, 2, 0])),
+    ]
+    _, labels = collate_fn(batch)
+    assert labels.shape == (2, 5)
+    # Short sequence padded with -1
+    assert labels[0, 2].item() == -1
+    assert labels[0, 3].item() == -1
+    assert labels[0, 4].item() == -1
+
+
+def test_collate_fn_single_item():
+    """Batch of one item should work without errors."""
+    from src.data.protein_dataset import tokenize
+    batch = [(tokenize("ACDEF"), torch.zeros(5, dtype=torch.long))]
+    tokens, labels = collate_fn(batch)
+    assert tokens.shape == (1, 5)
+    assert labels.shape == (1, 5)
+
+
+# ---------------------------------------------------------------------------
+# Label vocabularies
+# ---------------------------------------------------------------------------
+
+def test_ss3_label_map():
+    """SS3 label map has exactly 3 classes: C, H, E."""
+    assert set(SS3_LABEL_MAP.keys()) == {"C", "H", "E"}
+    assert set(SS3_LABEL_MAP.values()) == {0, 1, 2}
+
+
+def test_ss8_label_map():
+    """SS8 label map has exactly 8 classes."""
+    assert len(SS8_LABEL_MAP) == 8
+    assert set(SS8_LABEL_MAP.values()) == set(range(8))
+
+
+# ---------------------------------------------------------------------------
+# MSADataset
+# ---------------------------------------------------------------------------
+
+def test_msa_dataset_len():
+    """MSADataset.__len__ returns the number of sequences."""
+    seqs = ["ACDEF", "GHIKL", "MNPQR"]
+    ds = MSADataset(seqs, n_pseudo=4)
+    assert len(ds) == 3
+
+
+def test_msa_dataset_getitem_shapes():
+    """MSADataset.__getitem__ without labels returns (tokens, msa_features)."""
+    seqs = ["ACDEF", "GHIKL"]
+    ds = MSADataset(seqs, n_pseudo=5)
+    item = ds[0]
+    tokens, msa_feat = item   # no labels
+    L = 5
+    from src.data.msa_encoder import FEATURE_DIM
+    assert tokens.shape == (L,)
+    # n_pseudo=5 → 5+1=6 sequences (query + 5 homologs)
+    assert msa_feat.shape[1] == L
+    assert msa_feat.shape[2] == FEATURE_DIM
+
+
+def test_collate_msa_fn_output_shapes():
+    """collate_msa_fn pads tokens and MSA features to batch max length."""
+    seqs = ["ACF", "GHIKL"]
+    ds = MSADataset(seqs, n_pseudo=3)
+    loader = DataLoader(ds, batch_size=2, collate_fn=collate_msa_fn)
+    batch = next(iter(loader))
+    # Without labels, returns (tokens, msa, None) or (tokens, msa)
+    tokens, msa_feat = batch[0], batch[1]
+    B, max_L = 2, 5
+    from src.data.msa_encoder import FEATURE_DIM
+    assert tokens.shape == (B, max_L)
+    assert msa_feat.shape[0] == B
+    assert msa_feat.shape[2] == max_L
+    assert msa_feat.shape[3] == FEATURE_DIM

--- a/tests/data/test_msa_encoder.py
+++ b/tests/data/test_msa_encoder.py
@@ -1,0 +1,100 @@
+"""Tests for src/data/msa_encoder.py — MSA feature encoding.
+
+MSA homolog count behavior
+--------------------------
+MSAEncoder.encode() accepts a list of pre-aligned sequences and returns an
+(N_seq, L, FEATURE_DIM) tensor where N_seq equals len(sequences).  The encoder
+does NOT enforce a fixed N_seq across calls — that is the caller's responsibility
+when constructing batches.  MSADataset uses a fixed n_pseudo per dataset, so all
+items in a batch have the same N_seq.
+"""
+
+import torch
+import pytest
+
+from src.data.msa_encoder import (
+    FEATURE_DIM,
+    ONE_HOT_DIM,
+    MSAEncoder,
+    MSAFeatures,
+    generate_pseudo_msa,
+    encode_single_sequence,
+)
+
+
+def test_feature_dim_constant():
+    """FEATURE_DIM must be 45 (22 one-hot + 1 deletion + 22 profile)."""
+    assert FEATURE_DIM == 45
+    assert ONE_HOT_DIM == 22
+
+
+def test_encode_single_sequence_shape():
+    """encode_single_sequence produces MSAFeatures with shape (1, L, FEATURE_DIM)."""
+    result = encode_single_sequence("ACDEF")
+    assert isinstance(result, MSAFeatures)
+    assert result.features.shape == (1, 5, FEATURE_DIM)
+    assert result.features.dtype == torch.float32
+
+
+def test_msa_encoder_fixed_depth():
+    """MSAEncoder.encode() returns (N_seq, L, FEATURE_DIM) with N_seq from input."""
+    seqs = ["ACDEF", "ACDEF", "GHIKL"]  # N=3
+    enc = MSAEncoder()
+    result = enc.encode(seqs)
+    assert result.features.shape == (3, 5, FEATURE_DIM)
+    assert result.n_seq == 3
+    assert result.seq_len == 5
+
+
+def test_msa_encoder_variable_depth():
+    """MSAEncoder.encode() supports variable N_seq across calls — no fixed-depth constraint.
+
+    Design decision: N_seq is caller-controlled.  The encoder does not enforce
+    a uniform depth across batches.  MSADataset fixes this via n_pseudo.
+    """
+    enc = MSAEncoder()
+    r3 = enc.encode(["ACDEF", "GHIKL", "MNPQR"])
+    r5 = enc.encode(["ACDEF", "GHIKL", "MNPQR", "STVWY", "ACDEG"])
+    assert r3.features.shape[0] == 3
+    assert r5.features.shape[0] == 5
+
+
+def test_gap_feature():
+    """Gap characters ('-') should produce a 1.0 deletion feature at that position."""
+    enc = MSAEncoder()
+    feat = enc.encode(["A-C"]).features   # (1, 3, 45)
+    deletion_channel = ONE_HOT_DIM        # index 22 is the deletion dim
+    assert feat[0, 1, deletion_channel].item() == pytest.approx(1.0)
+    assert feat[0, 0, deletion_channel].item() == pytest.approx(0.0)
+    assert feat[0, 2, deletion_channel].item() == pytest.approx(0.0)
+
+
+def test_profile_shape():
+    """Profile portion of features should sum to ~1.0 per position (frequency distribution)."""
+    enc = MSAEncoder()
+    feat = enc.encode(["ACDEF", "ACDEF"]).features   # (2, 5, 45)
+    # Profile is the last 22 dims (indices 23..44)
+    profile = feat[0, :, ONE_HOT_DIM + 1:]           # (5, 22)
+    sums = profile.sum(dim=-1)
+    assert torch.allclose(sums, torch.ones(5), atol=1e-5)
+
+
+def test_generate_pseudo_msa_count():
+    """generate_pseudo_msa returns n_sequences+1 sequences (query + n_sequences homologs)."""
+    seqs = generate_pseudo_msa("ACDEF", n_sequences=7, mutation_rate=0.1, seed=0)
+    assert len(seqs) == 8          # query + 7 homologs
+    assert all(len(s) == 5 for s in seqs)
+    assert seqs[0] == "ACDEF"     # query is unchanged at index 0
+
+
+def test_generate_pseudo_msa_reproducible():
+    """Same seed produces identical pseudo-MSA."""
+    a = generate_pseudo_msa("ACDEF", n_sequences=4, seed=42)
+    b = generate_pseudo_msa("ACDEF", n_sequences=4, seed=42)
+    assert a == b
+
+
+def test_encode_single_residue():
+    """Single-residue sequence encodes without error."""
+    result = encode_single_sequence("A")
+    assert result.features.shape == (1, 1, FEATURE_DIM)

--- a/tests/data/test_pdb_parser.py
+++ b/tests/data/test_pdb_parser.py
@@ -1,0 +1,39 @@
+"""Tests for src/data/pdb_parser.py — tokenization constants and StructureData."""
+
+import torch
+import pytest
+
+from src.data.pdb_parser import BACKBONE_ATOMS, ATOM_INDEX, StructureData
+
+
+def test_backbone_atom_order():
+    """Backbone atom order must be [N, CA, C, O] — changing it breaks all consumers."""
+    assert BACKBONE_ATOMS == ["N", "CA", "C", "O"]
+
+
+def test_atom_index_keys():
+    """ATOM_INDEX must index all four backbone atoms at 0-3."""
+    assert ATOM_INDEX == {"N": 0, "CA": 1, "C": 2, "O": 3}
+
+
+def test_structure_data_len():
+    """StructureData.__len__ returns the sequence length."""
+    coords = torch.zeros(5, 4, 3)
+    sd = StructureData(sequence="ACDEF", coords=coords)
+    assert len(sd) == 5
+
+
+def test_structure_data_coord_shape():
+    """Coords tensor must be (L, 4, 3) float32."""
+    L = 10
+    coords = torch.randn(L, 4, 3)
+    sd = StructureData(sequence="A" * L, coords=coords)
+    assert sd.coords.shape == (L, 4, 3)
+
+
+def test_structure_data_empty_sequence():
+    """StructureData can hold an empty sequence (edge case)."""
+    coords = torch.zeros(0, 4, 3)
+    sd = StructureData(sequence="", coords=coords)
+    assert len(sd) == 0
+    assert sd.coords.shape == (0, 4, 3)

--- a/tests/data/test_protein_dataset.py
+++ b/tests/data/test_protein_dataset.py
@@ -1,0 +1,99 @@
+"""Tests for src/data/protein_dataset.py — tokenization and ProteinDataset."""
+
+import torch
+import pytest
+
+from src.data.protein_dataset import (
+    AA_TO_IDX,
+    IDX_TO_AA,
+    PAD_IDX,
+    UNK_IDX,
+    VOCAB_SIZE,
+    tokenize,
+    ProteinDataset,
+)
+
+_AA_ALPHABET = "ACDEFGHIKLMNPQRSTVWY"
+
+
+def test_vocab_size():
+    """VOCAB_SIZE should be 22 (20 AAs + PAD + UNK)."""
+    assert VOCAB_SIZE == 22
+
+
+def test_pad_unk_indices():
+    """PAD=0 and UNK=1 are reserved; amino acids start at 2."""
+    assert PAD_IDX == 0
+    assert UNK_IDX == 1
+
+
+def test_all_standard_aas_tokenized():
+    """All 20 standard amino acids must map to indices in [2, 21]."""
+    for aa in _AA_ALPHABET:
+        idx = AA_TO_IDX[aa]
+        assert 2 <= idx <= 21, f"{aa} → {idx} out of range"
+
+
+def test_aa_idx_roundtrip():
+    """AA_TO_IDX and IDX_TO_AA must be inverses."""
+    for aa, idx in AA_TO_IDX.items():
+        assert IDX_TO_AA[idx] == aa
+
+
+def test_tokenize_known_residues():
+    """Tokenize a known sequence and check every index is in [2, 21]."""
+    tokens = tokenize("ACDEF")
+    assert tokens.dtype == torch.long
+    assert tokens.shape == (5,)
+    assert tokens.min().item() >= 2
+    assert tokens.max().item() <= 21
+
+
+def test_tokenize_unknown_residue():
+    """Unknown characters (e.g. 'X') map to UNK_IDX."""
+    tokens = tokenize("AXZ")
+    assert tokens[1].item() == UNK_IDX
+    assert tokens[2].item() == UNK_IDX
+
+
+def test_tokenize_case_insensitive():
+    """Lowercase amino acids should tokenize the same as uppercase."""
+    upper = tokenize("ACDEF")
+    lower = tokenize("acdef")
+    assert torch.equal(upper, lower)
+
+
+def test_tokenize_single_residue():
+    """Single-residue sequence tokenizes to a length-1 tensor."""
+    tokens = tokenize("A")
+    assert tokens.shape == (1,)
+
+
+def test_protein_dataset_len():
+    """ProteinDataset.__len__ returns number of sequences."""
+    ds = ProteinDataset(["ACDEF", "GHIKL", "MNP"])
+    assert len(ds) == 3
+
+
+def test_protein_dataset_getitem_no_labels():
+    """Without labels, __getitem__ returns a token tensor."""
+    ds = ProteinDataset(["ACDEF"])
+    item = ds[0]
+    assert isinstance(item, torch.Tensor)
+    assert item.shape == (5,)
+
+
+def test_protein_dataset_getitem_with_labels():
+    """With labels, __getitem__ returns (tokens, labels) tuple."""
+    seqs = ["ACDEF", "GHI"]
+    labels = [torch.zeros(5, dtype=torch.long), torch.ones(3, dtype=torch.long)]
+    ds = ProteinDataset(seqs, labels=labels)
+    tokens, lab = ds[0]
+    assert tokens.shape == (5,)
+    assert lab.shape == (5,)
+
+
+def test_protein_dataset_length_mismatch_raises():
+    """Mismatched sequences and labels should raise ValueError."""
+    with pytest.raises(ValueError):
+        ProteinDataset(["ACDEF"], labels=[torch.zeros(5), torch.zeros(5)])


### PR DESCRIPTION
## Summary
Adds 35 pytest unit tests covering all data pipeline modules. Addresses the top development priority listed in the README.

## What Changed
- \`tests/data/__init__.py\`
- \`tests/data/test_pdb_parser.py\` — backbone atom constants, StructureData contracts
- \`tests/data/test_protein_dataset.py\` — tokenizer, vocab, ProteinDataset shape contracts
- \`tests/data/test_msa_encoder.py\` — MSAEncoder API, gap features, profile frequencies, pseudo-MSA generation; includes design-decision comment on variable vs fixed N_seq
- \`tests/data/test_loaders.py\` — collate_fn padding/masking, MSADataset shape contracts, collate_msa_fn

## Reviewer Notes
- All 35 tests use synthetic in-memory data only — no network calls, no file downloads
- The MSA N_seq design decision is documented in test_msa_encoder.py: N_seq is caller-controlled; the encoder does not enforce a fixed depth
- Tests discovered that MSAEncoder uses \`.encode(seqs)\` not \`__call__\`; and \`generate_pseudo_msa\` uses \`n_sequences=\` kwarg not \`n=\`

## Test Plan
- [x] \`pytest tests/data/ -v\` → 35 passed in 3.32s