### PR TITLE
test(integration): 19 integration tests — training loops, checkpoints, data pipeline

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+markers =
+    integration: end-to-end integration tests (training loops, checkpoints, data pipeline)

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,8 +4,6 @@ torchvision>=0.17.0
 
 # Data & biology
 biopython>=1.83
-biotite>=0.40.0
-prody>=2.4.1
 numpy>=1.26.0
 pandas>=2.2.0
 scikit-learn>=1.4.0

--- a/tests/integration/test_checkpoint.py
+++ b/tests/integration/test_checkpoint.py
@@ -1,0 +1,134 @@
+"""Integration tests: checkpoint save → load → inference cycle."""
+
+import math
+import torch
+import pytest
+
+pytestmark = pytest.mark.integration
+
+VOCAB_SIZE = 22
+MSA_FEAT_DIM = 45
+B, L = 2, 15
+
+
+def _tokens(B=B, L=L):
+    return torch.randint(2, VOCAB_SIZE, (B, L))
+
+
+def _msa(B=B, N=4, L=L):
+    return torch.randn(B, N, L, MSA_FEAT_DIM)
+
+
+# ---------------------------------------------------------------------------
+# StructureModule (MSA path) checkpoint tests
+# ---------------------------------------------------------------------------
+
+def test_checkpoint_roundtrip_msa_structure_model(tmp_path):
+    """Save and reload MSA StructureModule; inference output is finite and correct shape."""
+    from src.models.structure_module import build_msa_structure_model
+
+    model = build_msa_structure_model(n_blocks=1, c_m=32, c_z=16, use_frames=True, use_triangle=False)
+    ckpt_path = tmp_path / "msa_model.pt"
+    torch.save({"model_state": model.state_dict(), "args": {"n_blocks": 1, "c_m": 32, "c_z": 16}}, ckpt_path)
+
+    model2 = build_msa_structure_model(n_blocks=1, c_m=32, c_z=16, use_frames=True, use_triangle=False)
+    ckpt = torch.load(ckpt_path, map_location="cpu", weights_only=False)
+    model2.load_state_dict(ckpt["model_state"])
+    model2.eval()
+
+    with torch.no_grad():
+        out = model2(_tokens(), msa_features=_msa())
+
+    assert out.ca_coords.shape == (B, L, 3)
+    assert out.ca_coords.isfinite().all(), "ca_coords contains NaN/Inf after checkpoint reload"
+
+
+def test_checkpoint_state_dict_keys_match(tmp_path):
+    """State dict keys are identical before and after save/load."""
+    from src.models.structure_module import build_msa_structure_model
+
+    model = build_msa_structure_model(n_blocks=1, c_m=32, c_z=16, use_triangle=False)
+    ckpt_path = tmp_path / "keys_test.pt"
+    torch.save({"model_state": model.state_dict()}, ckpt_path)
+
+    ckpt = torch.load(ckpt_path, map_location="cpu", weights_only=False)
+    assert set(model.state_dict().keys()) == set(ckpt["model_state"].keys())
+
+
+def test_checkpoint_args_roundtrip(tmp_path):
+    """Training args survive the checkpoint round-trip exactly."""
+    from src.models.structure_module import build_msa_structure_model
+
+    args = {"n_blocks": 1, "c_m": 32, "c_z": 16, "lr": 1e-3, "epochs": 10, "use_triangle": False}
+    model = build_msa_structure_model(n_blocks=1, c_m=32, c_z=16, use_triangle=False)
+    ckpt_path = tmp_path / "args_test.pt"
+    torch.save({"model_state": model.state_dict(), "args": args}, ckpt_path)
+
+    ckpt = torch.load(ckpt_path, map_location="cpu", weights_only=False)
+    assert ckpt["args"] == args
+
+
+def test_inference_reproducible_after_load(tmp_path):
+    """Two models loaded from the same checkpoint produce identical outputs."""
+    from src.models.structure_module import build_msa_structure_model
+
+    model = build_msa_structure_model(n_blocks=1, c_m=32, c_z=16, use_frames=True, use_triangle=False)
+    ckpt_path = tmp_path / "repro_test.pt"
+    torch.save({"model_state": model.state_dict()}, ckpt_path)
+
+    def _load():
+        m = build_msa_structure_model(n_blocks=1, c_m=32, c_z=16, use_frames=True, use_triangle=False)
+        ckpt = torch.load(ckpt_path, map_location="cpu", weights_only=False)
+        m.load_state_dict(ckpt["model_state"])
+        m.eval()
+        return m
+
+    tokens = _tokens(B=1, L=10)
+    msa = _msa(B=1, N=4, L=10)
+
+    with torch.no_grad():
+        out1 = _load()(tokens, msa_features=msa)
+        out2 = _load()(tokens, msa_features=msa)
+
+    assert torch.allclose(out1.ca_coords, out2.ca_coords), \
+        "Outputs differ between two models loaded from the same checkpoint"
+
+
+# ---------------------------------------------------------------------------
+# Baseline model checkpoint tests
+# ---------------------------------------------------------------------------
+
+def test_baseline_checkpoint_roundtrip(tmp_path):
+    """BiLSTM baseline: save, reload, run inference — shape and finite check."""
+    from src.models.baseline import build_model, SS3_CLASSES
+
+    model = build_model(kind="bilstm", n_classes=SS3_CLASSES)
+    ckpt_path = tmp_path / "baseline.pt"
+    torch.save({"model_state": model.state_dict(), "args": {"kind": "bilstm"}}, ckpt_path)
+
+    model2 = build_model(kind="bilstm", n_classes=SS3_CLASSES)
+    ckpt = torch.load(ckpt_path, map_location="cpu", weights_only=False)
+    model2.load_state_dict(ckpt["model_state"])
+    model2.eval()
+
+    with torch.no_grad():
+        out = model2(_tokens())
+
+    assert out.shape == (B, L, SS3_CLASSES)
+    assert out.isfinite().all(), "baseline logits contain NaN/Inf after checkpoint reload"
+
+
+def test_checkpoint_weights_are_preserved(tmp_path):
+    """Parameter values are numerically identical after save/load."""
+    from src.models.baseline import build_model, SS3_CLASSES
+
+    model = build_model(kind="bilstm", n_classes=SS3_CLASSES)
+    ckpt_path = tmp_path / "weights_test.pt"
+    torch.save({"model_state": model.state_dict()}, ckpt_path)
+
+    model2 = build_model(kind="bilstm", n_classes=SS3_CLASSES)
+    ckpt = torch.load(ckpt_path, map_location="cpu", weights_only=False)
+    model2.load_state_dict(ckpt["model_state"])
+
+    for (n1, p1), (n2, p2) in zip(model.named_parameters(), model2.named_parameters()):
+        assert torch.allclose(p1, p2), f"Parameter mismatch after reload: {n1}"

--- a/tests/integration/test_data_to_model.py
+++ b/tests/integration/test_data_to_model.py
@@ -1,0 +1,206 @@
+"""Integration tests: full data pipeline through model forward pass + recycling."""
+
+import math
+import torch
+import pytest
+from torch.utils.data import DataLoader
+
+pytestmark = pytest.mark.integration
+
+VOCAB_SIZE = 22
+MSA_FEAT_DIM = 45
+
+# Synthetic amino acid sequences (all standard AAs)
+_AAS = "ACDEFGHIKLMNPQRSTVWY"
+_SEQS = [
+    "ACDEFGHIKLMNPQRSTVWY",      # L=20
+    "MKTAYIAKQRQISFVKSHFSRQ",    # L=22
+    "GVPQLQSRLK",                # L=10
+    "ACDEFGHIK",                 # L=9 (shortest, for padding test)
+]
+
+
+# ---------------------------------------------------------------------------
+# Helper
+# ---------------------------------------------------------------------------
+
+def _make_dataset(seqs=None, n_pseudo=4, seed=0):
+    from src.data.loaders import MSADataset
+    return MSADataset(seqs or _SEQS, n_pseudo=n_pseudo, seed=seed)
+
+
+# ---------------------------------------------------------------------------
+# DataLoader → Evoformer
+# ---------------------------------------------------------------------------
+
+def test_dataloader_to_evoformer():
+    """MSADataset → DataLoader → collate_msa_fn → EvoformerStack produces correct shapes."""
+    from src.data.loaders import collate_msa_fn
+    from src.models.evoformer import build_evoformer, EvoformerOutput
+
+    ds = _make_dataset()
+    loader = DataLoader(ds, batch_size=2, collate_fn=collate_msa_fn)
+    tokens, msa, _ = next(iter(loader))   # (B, L), (B, N, L, 45), None
+
+    B, L = tokens.shape
+    N = msa.shape[1]
+
+    evo = build_evoformer(n_blocks=1, c_m=32, c_z=16, nhead=4, c_outer=8, c_t=8)
+    out = evo(msa)
+
+    assert isinstance(out, EvoformerOutput)
+    assert out.msa_repr.shape == (B, N, L, 32)
+    assert out.pair_repr.shape == (B, L, L, 16)
+    assert out.query_repr.shape == (B, L, 32)
+    assert out.msa_repr.isfinite().all()
+    assert out.pair_repr.isfinite().all()
+
+
+def test_dataloader_to_structure_module():
+    """Full pipeline: DataLoader batch → StructureModule → ca_coords finite and correct shape."""
+    from src.data.loaders import collate_msa_fn
+    from src.models.structure_module import build_msa_structure_model
+
+    ds = _make_dataset()
+    loader = DataLoader(ds, batch_size=2, collate_fn=collate_msa_fn)
+    tokens, msa, _ = next(iter(loader))
+
+    model = build_msa_structure_model(
+        n_blocks=1, c_m=32, c_z=16, use_frames=True, use_triangle=False
+    )
+    model.eval()
+    with torch.no_grad():
+        out = model(tokens, msa_features=msa)
+
+    B, L = tokens.shape
+    assert out.ca_coords.shape == (B, L, 3)
+    assert out.ca_coords.isfinite().all(), "ca_coords has NaN/Inf"
+
+
+# ---------------------------------------------------------------------------
+# Variable-length batch padding
+# ---------------------------------------------------------------------------
+
+def test_variable_length_batch_padding():
+    """collate_msa_fn pads variable-length sequences to max length in batch."""
+    from src.data.loaders import collate_msa_fn
+    from src.data.protein_dataset import PAD_IDX
+
+    # Use sequences of deliberately different lengths
+    seqs = ["ACG", "ACDEFGHIKLM", "MNPQ"]
+    ds = _make_dataset(seqs=seqs)
+    loader = DataLoader(ds, batch_size=3, collate_fn=collate_msa_fn)
+    tokens, msa, _ = next(iter(loader))
+
+    max_len = max(len(s) for s in seqs)
+    assert tokens.shape == (3, max_len), f"Expected (3, {max_len}), got {tokens.shape}"
+    assert msa.shape[2] == max_len, f"MSA L dim should be {max_len}, got {msa.shape[2]}"
+
+    # Shortest sequence (len=3) should have PAD tokens beyond position 3
+    # Find the batch index corresponding to "ACG"
+    for i, s in enumerate(seqs):
+        if len(s) < max_len:
+            assert (tokens[i, len(s):] == PAD_IDX).all(), \
+                f"Padding not applied correctly for seq {i}"
+
+
+def test_padded_batch_through_evoformer():
+    """A padded variable-length batch passes through EvoformerStack without error."""
+    from src.data.loaders import collate_msa_fn
+    from src.models.evoformer import build_evoformer
+
+    seqs = ["ACG", "ACDEFGHIKLM", "MNPQ"]
+    ds = _make_dataset(seqs=seqs)
+    loader = DataLoader(ds, batch_size=3, collate_fn=collate_msa_fn)
+    tokens, msa, _ = next(iter(loader))
+
+    evo = build_evoformer(n_blocks=1, c_m=32, c_z=16, nhead=4, c_outer=8, c_t=8)
+    out = evo(msa)
+    assert out.msa_repr.isfinite().all()
+
+
+# ---------------------------------------------------------------------------
+# RecycledEvoformer
+# ---------------------------------------------------------------------------
+
+def test_recycled_evoformer_output_shape():
+    """RecycledEvoformer returns (B, L, 3) ca_coords after all recycles."""
+    from src.models.evoformer import build_evoformer
+    from src.models.structure_module import build_msa_structure_model
+    from src.models.recycling import RecycledEvoformer
+
+    evo = build_evoformer(n_blocks=1, c_m=32, c_z=16, nhead=4, c_outer=8, c_t=8)
+    struct = build_msa_structure_model(
+        n_blocks=1, c_m=32, c_z=16, use_frames=True, use_triangle=False
+    )
+    model = RecycledEvoformer(evo, struct, num_recycles=3)
+
+    msa = torch.randn(1, 4, 20, MSA_FEAT_DIM)
+    evo_out, struct_out = model(msa)
+
+    assert struct_out.ca_coords.shape == (1, 20, 3)
+    assert struct_out.ca_coords.isfinite().all()
+
+
+def test_recycling_changes_output():
+    """RecycledEvoformer with num_recycles=3 produces different output than num_recycles=1."""
+    from src.models.evoformer import build_evoformer
+    from src.models.structure_module import build_msa_structure_model
+    from src.models.recycling import RecycledEvoformer
+
+    torch.manual_seed(0)
+    evo = build_evoformer(n_blocks=1, c_m=32, c_z=16, nhead=4, c_outer=8, c_t=8)
+    struct = build_msa_structure_model(
+        n_blocks=1, c_m=32, c_z=16, use_frames=True, use_triangle=False
+    )
+
+    msa = torch.randn(1, 4, 15, MSA_FEAT_DIM)
+
+    model1 = RecycledEvoformer(evo, struct, num_recycles=1)
+    model3 = RecycledEvoformer(evo, struct, num_recycles=3)
+
+    model1.eval()
+    model3.eval()
+    with torch.no_grad():
+        _, out1 = model1(msa)
+        _, out3 = model3(msa)
+
+    assert not torch.allclose(out1.ca_coords, out3.ca_coords), \
+        "Recycling had no effect — 1 and 3 recycles produced identical outputs"
+
+
+# ---------------------------------------------------------------------------
+# Gradient flow: full pipeline
+# ---------------------------------------------------------------------------
+
+def test_gradient_flow_dataloader_to_loss():
+    """Full pipeline: DataLoader → StructureModule → fape_loss → backward succeeds."""
+    from src.data.loaders import collate_msa_fn
+    from src.models.structure_module import build_msa_structure_model
+    from src.training.losses import fape_loss
+
+    ds = _make_dataset(seqs=["ACDEFGHIKL", "MNPQRSTVWY"])
+    loader = DataLoader(ds, batch_size=2, collate_fn=collate_msa_fn)
+    tokens, msa, _ = next(iter(loader))
+
+    B, L = tokens.shape
+    model = build_msa_structure_model(
+        n_blocks=1, c_m=32, c_z=16, use_frames=True, use_triangle=False
+    )
+    opt = torch.optim.Adam(model.parameters(), lr=1e-3)
+
+    true_ca = torch.randn(B, L, 3)
+    true_R = torch.eye(3).unsqueeze(0).unsqueeze(0).expand(B, L, 3, 3)
+    seq_mask = torch.ones(B, L, dtype=torch.bool)
+
+    opt.zero_grad()
+    out = model(tokens, msa_features=msa)
+    pred_R = out.rotations if out.rotations is not None else true_R
+    loss = fape_loss(out.ca_coords, true_ca, pred_R, true_R, seq_mask)
+    loss.backward()
+    opt.step()
+
+    assert math.isfinite(loss.item()), f"loss is not finite: {loss.item()}"
+    grads = [p.grad for p in model.parameters() if p.grad is not None]
+    assert len(grads) > 0, "no gradients after backward"
+    assert all(g.isfinite().all() for g in grads), "NaN/Inf gradient detected"

--- a/tests/integration/test_training_loops.py
+++ b/tests/integration/test_training_loops.py
@@ -1,0 +1,205 @@
+"""Integration tests: one optimizer step for each training script's core loop.
+
+Each test verifies:
+  - Loss is a finite, non-negative scalar
+  - backward() completes without error
+  - At least one model parameter receives a gradient
+"""
+
+import math
+import torch
+import torch.nn as nn
+import pytest
+
+pytestmark = pytest.mark.integration
+
+# Small dims shared across all tests for fast execution
+B, L = 2, 20
+VOCAB_SIZE = 22
+MSA_FEAT_DIM = 45
+
+
+def _tokens(B=B, L=L):
+    return torch.randint(2, VOCAB_SIZE, (B, L))
+
+
+def _msa(B=B, N=4, L=L):
+    return torch.randn(B, N, L, MSA_FEAT_DIM)
+
+
+def _seq_mask(B=B, L=L):
+    return torch.ones(B, L, dtype=torch.bool)
+
+
+def _assert_valid_loss(loss):
+    assert loss.shape == (), "loss must be scalar"
+    assert math.isfinite(loss.item()), f"loss is not finite: {loss.item()}"
+    assert loss.item() >= 0.0, f"loss is negative: {loss.item()}"
+
+
+def _assert_gradients(model):
+    grads = [p.grad for p in model.parameters() if p.grad is not None]
+    assert len(grads) > 0, "no parameter received a gradient"
+    assert all(g.isfinite().all() for g in grads), "NaN/Inf gradient detected"
+
+
+# ---------------------------------------------------------------------------
+# Baseline (SS3 secondary structure)
+# ---------------------------------------------------------------------------
+
+def test_baseline_bilstm_training_step():
+    """BiLSTM SS3 model: one forward+backward step produces finite loss and gradients."""
+    from src.models.baseline import BiLSTMModel, SS3_CLASSES
+
+    model = BiLSTMModel(embed_dim=16, hidden_dim=16, num_layers=1, n_classes=SS3_CLASSES)
+    opt = torch.optim.Adam(model.parameters(), lr=1e-3)
+
+    tokens = _tokens()
+    labels = torch.randint(0, SS3_CLASSES, (B, L))
+
+    opt.zero_grad()
+    logits = model(tokens)                            # (B, L, 3)
+    loss = nn.CrossEntropyLoss()(logits.reshape(-1, SS3_CLASSES), labels.reshape(-1))
+    loss.backward()
+    opt.step()
+
+    _assert_valid_loss(loss)
+    _assert_gradients(model)
+
+
+def test_baseline_transformer_training_step():
+    """Transformer SS3 model: one forward+backward step produces finite loss and gradients."""
+    from src.models.baseline import TransformerModel, SS3_CLASSES
+
+    model = TransformerModel(d_model=16, nhead=2, num_layers=1, n_classes=SS3_CLASSES)
+    opt = torch.optim.Adam(model.parameters(), lr=1e-3)
+
+    tokens = _tokens()
+    labels = torch.randint(0, SS3_CLASSES, (B, L))
+
+    opt.zero_grad()
+    logits = model(tokens)
+    loss = nn.CrossEntropyLoss()(logits.reshape(-1, SS3_CLASSES), labels.reshape(-1))
+    loss.backward()
+    opt.step()
+
+    _assert_valid_loss(loss)
+    _assert_gradients(model)
+
+
+# ---------------------------------------------------------------------------
+# Contact prediction
+# ---------------------------------------------------------------------------
+
+def test_contact_training_step():
+    """ContactPredictor: one forward+backward step with BCE loss."""
+    from src.models.contact_predictor import build_contact_model
+    from src.training.losses import contact_bce_loss, make_contact_mask
+
+    model = build_contact_model(kind="bilstm", hidden_dim=16, num_layers=1)
+    opt = torch.optim.Adam(model.parameters(), lr=1e-3)
+
+    tokens = _tokens()
+    targets = torch.randint(0, 2, (B, L, L)).float()
+    lengths = torch.full((B,), L)
+    mask = make_contact_mask(lengths, L=L, sep_min=1)
+
+    opt.zero_grad()
+    logits = model(tokens)                           # (B, L, L)
+    loss = contact_bce_loss(logits, targets, mask)
+    loss.backward()
+    opt.step()
+
+    _assert_valid_loss(loss)
+    _assert_gradients(model)
+
+
+# ---------------------------------------------------------------------------
+# Structure module (encoder path)
+# ---------------------------------------------------------------------------
+
+def test_structure_encoder_training_step():
+    """StructureModule (BiLSTM encoder): one step with FAPE loss."""
+    from src.models.structure_module import build_structure_model
+    from src.training.losses import fape_loss
+
+    model = build_structure_model(kind="bilstm", hidden_dim=16, num_layers=1, use_frames=True)
+    opt = torch.optim.Adam(model.parameters(), lr=1e-3)
+
+    tokens = _tokens()
+    true_ca = torch.randn(B, L, 3)
+    true_R = torch.eye(3).unsqueeze(0).unsqueeze(0).expand(B, L, 3, 3)
+    seq_mask = _seq_mask()
+
+    opt.zero_grad()
+    out = model(tokens)
+    pred_R = out.rotations if out.rotations is not None else true_R
+    loss = fape_loss(out.ca_coords, true_ca, pred_R, true_R, seq_mask)
+    loss.backward()
+    opt.step()
+
+    _assert_valid_loss(loss)
+    _assert_gradients(model)
+
+
+# ---------------------------------------------------------------------------
+# End-to-end (Evoformer + structure module)
+# ---------------------------------------------------------------------------
+
+def test_end_to_end_training_step():
+    """Full MSA → Evoformer → StructureModule pipeline: one step with FAPE loss."""
+    from src.models.structure_module import build_msa_structure_model
+    from src.training.losses import fape_loss
+
+    model = build_msa_structure_model(
+        n_blocks=1, c_m=32, c_z=16, use_frames=True, use_triangle=False
+    )
+    opt = torch.optim.Adam(model.parameters(), lr=1e-3)
+
+    tokens = _tokens()
+    msa_feat = _msa()
+    true_ca = torch.randn(B, L, 3)
+    true_R = torch.eye(3).unsqueeze(0).unsqueeze(0).expand(B, L, 3, 3)
+    seq_mask = _seq_mask()
+
+    opt.zero_grad()
+    out = model(tokens, msa_features=msa_feat)
+    pred_R = out.rotations if out.rotations is not None else true_R
+    loss = fape_loss(out.ca_coords, true_ca, pred_R, true_R, seq_mask)
+    loss.backward()
+    opt.step()
+
+    _assert_valid_loss(loss)
+    _assert_gradients(model)
+
+
+def test_end_to_end_loss_decreases_over_steps():
+    """Loss should decrease (or at least not increase) over several optimizer steps."""
+    from src.models.structure_module import build_msa_structure_model
+    from src.training.losses import fape_loss
+
+    torch.manual_seed(42)
+    model = build_msa_structure_model(
+        n_blocks=1, c_m=32, c_z=16, use_frames=True, use_triangle=False
+    )
+    opt = torch.optim.Adam(model.parameters(), lr=1e-2)
+
+    tokens = _tokens(B=1, L=10)
+    msa_feat = _msa(B=1, N=4, L=10)
+    true_ca = torch.randn(1, 10, 3)
+    true_R = torch.eye(3).unsqueeze(0).unsqueeze(0).expand(1, 10, 3, 3)
+    seq_mask = torch.ones(1, 10, dtype=torch.bool)
+
+    losses = []
+    for _ in range(5):
+        opt.zero_grad()
+        out = model(tokens, msa_features=msa_feat)
+        pred_R = out.rotations if out.rotations is not None else true_R
+        loss = fape_loss(out.ca_coords, true_ca, pred_R, true_R, seq_mask)
+        loss.backward()
+        opt.step()
+        losses.append(loss.item())
+
+    assert all(math.isfinite(v) for v in losses), f"NaN/Inf in losses: {losses}"
+    # Loss over 5 steps should decrease at least once (not strictly monotone)
+    assert losses[-1] < losses[0], f"Loss did not decrease: {losses}"


### PR DESCRIPTION
## Summary
- **Training loops** (6 tests): one optimizer step for BiLSTM, Transformer, ContactPredictor, StructureModule (encoder path), and MSA end-to-end path; plus a 5-step loss-decreases regression test
- **Checkpoint lifecycle** (6 tests): save → load → inference shape/value, weight preservation, args round-trip, reproducibility across two independent loads
- **Data pipeline → model** (7 tests): `MSADataset → DataLoader → collate_msa_fn → EvoformerStack / StructureModule`, variable-length padding through Evoformer, `RecycledEvoformer` output shape and recycling-changes-output assertion, full gradient flow from DataLoader through `fape_loss`
- **pytest.ini**: registers `integration` mark to suppress pytest warnings
- **requirements.txt**: removes unused `biotite` and `prody` (build failures, nothing imports them)

## Test plan
- [ ] `pytest tests/ -q` → 110 passed
- [ ] `pytest -m integration -v` → 19 passed
- [ ] No NaN/Inf warnings in any test output

🤖 Generated with [Claude Code](https://claude.com/claude-code)