### PR TITLE
feat(data): real MSA support via ColabFold API with disk caching

### DIFF
--- a/scripts/prefetch_msas.py
+++ b/scripts/prefetch_msas.py
@@ -1,0 +1,216 @@
+"""
+Pre-fetch and cache real MSAs from the ColabFold API.
+
+Run this once before training to populate the MSA cache. The training
+script will then load MSAs from disk without any API calls.
+
+Usage
+-----
+  # From a list of PDB IDs (downloads structures, extracts sequences)
+  python scripts/prefetch_msas.py --pdb-ids 1UBQ,1CRN,4HHB
+
+  # From a plain-text file of sequences (one per line)
+  python scripts/prefetch_msas.py --sequence-file sequences.txt
+
+  # From a FASTA file
+  python scripts/prefetch_msas.py --fasta proteins.fasta
+
+  # Save to a custom cache directory (default: msa_cache/)
+  python scripts/prefetch_msas.py --pdb-ids 1UBQ,1CRN --cache-dir /data/msa_cache
+
+  # Limit MSA depth (to control memory usage during training)
+  python scripts/prefetch_msas.py --pdb-ids 1UBQ --max-depth 128
+
+On Google Colab, save to Drive so the cache persists across sessions:
+  python scripts/prefetch_msas.py --pdb-ids 1UBQ,1CRN \\
+      --cache-dir /content/drive/MyDrive/mini-alphafold/msa_cache
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+import time
+import urllib.request
+import tempfile
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+
+# ---------------------------------------------------------------------------
+# Sequence loading helpers
+# ---------------------------------------------------------------------------
+
+def _load_from_fasta(path: Path) -> list[str]:
+    """Parse a FASTA file and return the sequences (no headers)."""
+    sequences: list[str] = []
+    current: list[str] = []
+    with open(path, encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if line.startswith(">"):
+                if current:
+                    sequences.append("".join(current))
+                current = []
+            elif line:
+                current.append(line)
+    if current:
+        sequences.append("".join(current))
+    return sequences
+
+
+def _load_from_sequence_file(path: Path) -> list[str]:
+    """Load one sequence per line from a plain text file."""
+    with open(path, encoding="utf-8") as f:
+        return [line.strip() for line in f if line.strip()]
+
+
+def _fetch_sequence_from_pdb(pdb_id: str) -> str:
+    """Download a PDB file from RCSB and extract the SEQRES sequence."""
+    from src.data.pdb_parser import parse_structure_file
+
+    url = f"https://files.rcsb.org/download/{pdb_id.upper()}.pdb"
+    print(f"  Downloading {pdb_id.upper()} from RCSB…", flush=True)
+    with tempfile.NamedTemporaryFile(suffix=".pdb", delete=False) as tmp:
+        tmp_path = Path(tmp.name)
+    try:
+        urllib.request.urlretrieve(url, tmp_path)
+        struct = parse_structure_file(tmp_path)
+        return struct.sequence
+    finally:
+        tmp_path.unlink(missing_ok=True)
+
+
+def _load_sequences(args: argparse.Namespace) -> list[tuple[str, str]]:
+    """Return list of (label, sequence) pairs from whichever source was given."""
+    pairs: list[tuple[str, str]] = []
+
+    if args.pdb_ids:
+        for pdb_id in args.pdb_ids.split(","):
+            pdb_id = pdb_id.strip()
+            if not pdb_id:
+                continue
+            try:
+                seq = _fetch_sequence_from_pdb(pdb_id)
+                pairs.append((pdb_id.upper(), seq))
+            except Exception as exc:
+                print(f"  WARNING: could not load {pdb_id}: {exc}", flush=True)
+
+    if args.fasta:
+        seqs = _load_from_fasta(Path(args.fasta))
+        for i, seq in enumerate(seqs):
+            pairs.append((f"fasta_{i}", seq))
+
+    if args.sequence_file:
+        seqs = _load_from_sequence_file(Path(args.sequence_file))
+        for i, seq in enumerate(seqs):
+            pairs.append((f"seq_{i}", seq))
+
+    return pairs
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main(args: argparse.Namespace) -> None:
+    from src.data.msa_fetcher import fetch_msa, _load_cache
+
+    cache_dir = Path(args.cache_dir)
+    cache_dir.mkdir(parents=True, exist_ok=True)
+
+    print(f"MSA cache directory: {cache_dir.resolve()}")
+    print(f"ColabFold mode: {args.mode}  |  max depth: {args.max_depth}\n")
+
+    pairs = _load_sequences(args)
+    if not pairs:
+        print("No sequences to process. Use --pdb-ids, --fasta, or --sequence-file.")
+        sys.exit(1)
+
+    print(f"Sequences to process: {len(pairs)}\n")
+
+    success = 0
+    skipped = 0
+    failed = 0
+
+    for i, (label, seq) in enumerate(pairs):
+        print(f"[{i+1}/{len(pairs)}] {label}  (L={len(seq)})", flush=True)
+
+        # Check cache first
+        if not args.force and _load_cache(cache_dir, seq) is not None:
+            print(f"  → already cached, skipping", flush=True)
+            skipped += 1
+            continue
+
+        try:
+            msa = fetch_msa(
+                seq,
+                cache_dir=cache_dir,
+                max_msa_depth=args.max_depth,
+                mode=args.mode,
+            )
+            print(f"  → {len(msa)} sequences cached", flush=True)
+            success += 1
+        except Exception as exc:
+            print(f"  ERROR: {exc}", flush=True)
+            failed += 1
+
+        # Rate limit between submissions
+        if i < len(pairs) - 1:
+            time.sleep(args.delay)
+
+    print(f"\n{'='*50}")
+    print(f"Done. Success: {success}  Skipped: {skipped}  Failed: {failed}")
+    print(f"Cache: {cache_dir.resolve()}")
+    if failed:
+        print(f"WARNING: {failed} sequences failed. Re-run to retry.")
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(
+        description="Pre-fetch real MSAs from ColabFold and cache to disk.",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+
+    src = p.add_argument_group("sequence sources (at least one required)")
+    src.add_argument(
+        "--pdb-ids", type=str, default=None,
+        help="Comma-separated PDB IDs to fetch sequences from RCSB (e.g. 1UBQ,1CRN).",
+    )
+    src.add_argument(
+        "--fasta", type=str, default=None,
+        help="Path to a FASTA file of query sequences.",
+    )
+    src.add_argument(
+        "--sequence-file", type=str, default=None,
+        help="Path to a plain text file with one sequence per line.",
+    )
+
+    opt = p.add_argument_group("options")
+    opt.add_argument(
+        "--cache-dir", type=str, default="msa_cache",
+        help="Directory to store cached MSA JSON files.",
+    )
+    opt.add_argument(
+        "--max-depth", type=int, default=512,
+        help="Maximum number of MSA sequences to cache per protein.",
+    )
+    opt.add_argument(
+        "--mode", type=str, default="env", choices=["env", "all"],
+        help="ColabFold search mode. 'env' includes metagenomics sequences.",
+    )
+    opt.add_argument(
+        "--delay", type=float, default=1.0,
+        help="Seconds to wait between API submissions (rate limiting).",
+    )
+    opt.add_argument(
+        "--force", action="store_true",
+        help="Re-fetch even if a cache entry already exists.",
+    )
+
+    return p.parse_args()
+
+
+if __name__ == "__main__":
+    main(parse_args())

--- a/scripts/train_end_to_end.py
+++ b/scripts/train_end_to_end.py
@@ -102,8 +102,10 @@ except ImportError:
 class MSAStructureDataset(Dataset):
     """Dataset returning (tokens, msa_features, backbone_coords) per sample.
 
-    Wraps MSADataset to add structure coordinates.  Pseudo-MSAs are generated
-    automatically from the query sequence using random mutation.
+    Supports both pseudo-MSAs (default) and real pre-cached MSAs from the
+    ColabFold API (via --msa-cache).  When a cache directory is provided,
+    each sequence's real MSA is loaded from disk; sequences without a cache
+    entry fall back to pseudo-MSA automatically.
 
     Args:
         sequences:     List of amino-acid strings.
@@ -111,6 +113,10 @@ class MSAStructureDataset(Dataset):
         n_pseudo:      Number of pseudo-MSA homologues per query (default 8).
         mutation_rate: Per-residue substitution rate for pseudo-MSA (default 0.15).
         seed:          Optional RNG seed for reproducible pseudo-MSAs.
+        msa_cache_dir: Optional path to a pre-populated MSA cache directory.
+                       When provided, real MSAs are loaded from cache; missing
+                       entries fall back to pseudo-MSA silently.
+        max_msa_depth: Maximum number of MSA sequences to use per sample.
     """
 
     def __init__(
@@ -120,10 +126,35 @@ class MSAStructureDataset(Dataset):
         n_pseudo:      int   = 8,
         mutation_rate: float = 0.15,
         seed:          Optional[int] = None,
+        msa_cache_dir: Optional[str] = None,
+        max_msa_depth: int = 512,
     ) -> None:
         assert len(sequences) == len(coords), "sequences and coords must have equal length"
+
+        # Resolve MSA sequences: real from cache, or pseudo-generated
+        if msa_cache_dir is not None:
+            from src.data.msa_fetcher import load_cached_msa
+            msa_seqs_list = []
+            n_real = 0
+            for seq in sequences:
+                msa = load_cached_msa(
+                    seq,
+                    cache_dir=msa_cache_dir,
+                    max_msa_depth=max_msa_depth,
+                    fallback_pseudo=True,
+                    n_pseudo=n_pseudo,
+                )
+                msa_seqs_list.append(msa)
+                if not all(s == seq or "-" in s for s in msa[1:]):
+                    n_real += 1
+            print(f"  MSA source: {n_real}/{len(sequences)} from real cache, "
+                  f"{len(sequences)-n_real} pseudo-MSA fallback")
+        else:
+            msa_seqs_list = None
+
         self._msa_ds = MSADataset(
             sequences,
+            msa_sequences=msa_seqs_list,
             n_pseudo=n_pseudo,
             mutation_rate=mutation_rate,
             seed=seed,
@@ -227,12 +258,25 @@ def build_synthetic_msa_dataset(
 # ---------------------------------------------------------------------------
 
 def build_real_msa_dataset(
-    pdb_ids:      list[str],
-    n_pseudo:     int   = 8,
+    pdb_ids:       list[str],
+    n_pseudo:      int   = 8,
     mutation_rate: float = 0.15,
-    seed:         int   = 0,
+    seed:          int   = 0,
+    msa_cache_dir: Optional[str] = None,
+    max_msa_depth: int   = 512,
 ) -> MSAStructureDataset:
-    """Download PDB files from RCSB and build MSAStructureDataset."""
+    """Download PDB files from RCSB and build MSAStructureDataset.
+
+    Args:
+        pdb_ids:       List of 4-character PDB IDs.
+        n_pseudo:      Pseudo-MSA depth for sequences without a cache entry.
+        mutation_rate: Mutation rate for pseudo-MSA generation.
+        seed:          RNG seed.
+        msa_cache_dir: Optional path to a pre-populated MSA cache directory
+                       (created by scripts/prefetch_msas.py). When provided,
+                       real MSAs are used; missing entries fall back to pseudo.
+        max_msa_depth: Maximum MSA sequences per sample.
+    """
     try:
         from src.data.pdb_parser import parse_structure_file
     except ImportError as exc:
@@ -261,6 +305,7 @@ def build_real_msa_dataset(
     return MSAStructureDataset(
         sequences, coords_list,
         n_pseudo=n_pseudo, mutation_rate=mutation_rate, seed=seed,
+        msa_cache_dir=msa_cache_dir, max_msa_depth=max_msa_depth,
     )
 
 
@@ -482,8 +527,12 @@ def train(args: argparse.Namespace) -> None:
     elif args.pdb_ids:
         pdb_list = [p.strip().upper() for p in args.pdb_ids.split(",")]
         print(f"Loading real PDB structures: {pdb_list}")
+        if args.msa_cache:
+            print(f"Using real MSA cache: {args.msa_cache}")
         dataset = build_real_msa_dataset(
             pdb_list, n_pseudo=args.n_pseudo, seed=args.seed,
+            msa_cache_dir=args.msa_cache,
+            max_msa_depth=args.max_msa_depth,
         )
         n_val   = max(1, int(len(dataset) * 0.2))
         n_train = len(dataset) - n_val
@@ -675,6 +724,15 @@ def parse_args() -> argparse.Namespace:
                       help="Skip structures longer than this (cached mode).")
     data.add_argument("--n-pseudo",     type=int, default=8,
                       help="Number of pseudo-MSA homologues per query.")
+    data.add_argument("--msa-cache",    type=str, default=None,
+                      help=(
+                          "Path to a pre-populated MSA cache directory created by "
+                          "scripts/prefetch_msas.py. When provided, real MSAs are "
+                          "loaded from cache instead of pseudo-MSAs. Sequences "
+                          "without a cache entry fall back to pseudo-MSA silently."
+                      ))
+    data.add_argument("--max-msa-depth", type=int, default=512,
+                      help="Maximum MSA depth (number of homologs) per sample.")
     data.add_argument("--seed",         type=int, default=42)
 
     evo = p.add_argument_group("evoformer")

--- a/src/data/msa_fetcher.py
+++ b/src/data/msa_fetcher.py
@@ -1,0 +1,385 @@
+"""
+ColabFold MSA fetcher with disk-based caching.
+
+Queries the ColabFold MMseqs2 API to generate real MSAs for protein sequences,
+then caches results locally so training does not require repeated API calls.
+
+The ColabFold API is asynchronous:
+  1. POST /ticket/msa  →  job ID
+  2. Poll GET /ticket/{id}  →  wait for status == "COMPLETE"
+  3. GET /result/download/{id}  →  tar.gz containing .a3m files
+
+A3M format
+----------
+Each sequence is an aligned string where:
+  - Uppercase letters and '-' are alignment columns (same width as query)
+  - Lowercase letters are insertions relative to the query (removed here)
+
+After stripping lowercase, all sequences in the MSA have the same length as
+the query — ready for MSAEncoder.encode().
+
+Public API
+----------
+  fetch_msa(sequence, cache_dir, ...)  →  list[str]   (aligned sequences)
+  prefetch_msas(sequences, cache_dir, ...)             (bulk pre-caching)
+"""
+
+from __future__ import annotations
+
+import hashlib
+import io
+import json
+import logging
+import tarfile
+import time
+from pathlib import Path
+from typing import Optional
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+COLABFOLD_API = "https://api.colabfold.com"
+DEFAULT_POLL_INTERVAL = 5       # seconds between status polls
+DEFAULT_TIMEOUT = 300           # max seconds to wait for one job
+DEFAULT_MAX_MSA_DEPTH = 512     # cap homologs returned (memory budget)
+DEFAULT_REQUESTS_TIMEOUT = 30   # HTTP request timeout in seconds
+
+
+# ---------------------------------------------------------------------------
+# A3M parsing
+# ---------------------------------------------------------------------------
+
+def _parse_a3m(a3m_text: str) -> list[str]:
+    """Parse an A3M-format MSA into aligned sequences.
+
+    Strips insertion characters (lowercase letters) so every returned sequence
+    has the same length as the query (the first entry).
+
+    Args:
+        a3m_text: Raw A3M file contents as a string.
+
+    Returns:
+        List of aligned strings, query first. Empty sequences are skipped.
+    """
+    sequences: list[str] = []
+    current: list[str] = []
+
+    for line in a3m_text.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        if line.startswith(">"):
+            if current:
+                seq = "".join(current)
+                # Remove lowercase insertion characters
+                seq = "".join(ch for ch in seq if not ch.islower())
+                if seq:
+                    sequences.append(seq)
+            current = []
+        else:
+            current.append(line)
+
+    # Flush last entry
+    if current:
+        seq = "".join(current)
+        seq = "".join(ch for ch in seq if not ch.islower())
+        if seq:
+            sequences.append(seq)
+
+    return sequences
+
+
+def _extract_a3m_from_tar(tar_bytes: bytes) -> str:
+    """Extract the first .a3m file from a tar.gz byte payload.
+
+    The ColabFold API returns a tar.gz containing one or more .a3m files.
+    We prefer 'uniref.a3m' (UniRef90 hits) if present, otherwise take the
+    first .a3m found.
+
+    Args:
+        tar_bytes: Raw bytes from the API download endpoint.
+
+    Returns:
+        A3M file contents as a string.
+
+    Raises:
+        ValueError: If no .a3m file is found in the archive.
+    """
+    with tarfile.open(fileobj=io.BytesIO(tar_bytes), mode="r:gz") as tar:
+        names = tar.getnames()
+        # Prefer uniref.a3m, fall back to first .a3m
+        a3m_names = [n for n in names if n.endswith(".a3m")]
+        if not a3m_names:
+            raise ValueError(f"No .a3m file in ColabFold result. Files: {names}")
+        preferred = next((n for n in a3m_names if "uniref" in n), a3m_names[0])
+        member = tar.getmember(preferred)
+        f = tar.extractfile(member)
+        if f is None:
+            raise ValueError(f"Could not extract {preferred} from archive.")
+        return f.read().decode("utf-8", errors="replace")
+
+
+# ---------------------------------------------------------------------------
+# Cache helpers
+# ---------------------------------------------------------------------------
+
+def _cache_key(sequence: str) -> str:
+    """MD5 hex digest of the sequence — used as the cache filename."""
+    return hashlib.md5(sequence.upper().encode()).hexdigest()
+
+
+def _cache_path(cache_dir: Path, sequence: str) -> Path:
+    return cache_dir / f"{_cache_key(sequence)}.json"
+
+
+def _load_cache(cache_dir: Path, sequence: str) -> Optional[list[str]]:
+    """Return cached MSA sequences, or None if not cached."""
+    p = _cache_path(cache_dir, sequence)
+    if not p.exists():
+        return None
+    try:
+        data = json.loads(p.read_text(encoding="utf-8"))
+        return data["sequences"]
+    except Exception as exc:
+        logger.warning("Corrupt cache entry %s: %s", p, exc)
+        return None
+
+
+def _save_cache(cache_dir: Path, sequence: str, sequences: list[str]) -> None:
+    """Persist MSA sequences to disk cache."""
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    p = _cache_path(cache_dir, sequence)
+    p.write_text(
+        json.dumps({"query": sequence, "sequences": sequences}, indent=2),
+        encoding="utf-8",
+    )
+
+
+# ---------------------------------------------------------------------------
+# ColabFold API client
+# ---------------------------------------------------------------------------
+
+def _submit_job(sequence: str, mode: str = "env") -> str:
+    """Submit a sequence to the ColabFold MSA API and return the job ID.
+
+    Args:
+        sequence: Query amino acid string (no gaps).
+        mode:     'env' includes environmental sequences (metagenomics);
+                  'all' includes UniRef90 + BFD + MGnify + env.
+
+    Returns:
+        Job ID string.
+    """
+    fasta = f">query\n{sequence}"
+    response = requests.post(
+        f"{COLABFOLD_API}/ticket/msa",
+        data={"q": fasta, "mode": mode},
+        timeout=DEFAULT_REQUESTS_TIMEOUT,
+    )
+    response.raise_for_status()
+    data = response.json()
+    job_id = data.get("id")
+    if not job_id:
+        raise RuntimeError(f"ColabFold API returned no job ID: {data}")
+    return job_id
+
+
+def _poll_job(job_id: str, timeout: float = DEFAULT_TIMEOUT,
+              poll_interval: float = DEFAULT_POLL_INTERVAL) -> None:
+    """Block until the job is COMPLETE or raise on ERROR/timeout."""
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        response = requests.get(
+            f"{COLABFOLD_API}/ticket/{job_id}",
+            timeout=DEFAULT_REQUESTS_TIMEOUT,
+        )
+        response.raise_for_status()
+        status = response.json().get("status", "")
+        if status == "COMPLETE":
+            return
+        if status == "ERROR":
+            raise RuntimeError(f"ColabFold job {job_id} failed with status ERROR.")
+        logger.debug("Job %s status: %s — waiting %ss", job_id, status, poll_interval)
+        time.sleep(poll_interval)
+    raise TimeoutError(f"ColabFold job {job_id} did not complete within {timeout}s.")
+
+
+def _download_result(job_id: str) -> bytes:
+    """Download the tar.gz result for a completed job."""
+    response = requests.get(
+        f"{COLABFOLD_API}/result/download/{job_id}",
+        timeout=120,   # download can be large
+    )
+    response.raise_for_status()
+    return response.content
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+def fetch_msa(
+    sequence: str,
+    cache_dir: str | Path = "msa_cache",
+    max_msa_depth: int = DEFAULT_MAX_MSA_DEPTH,
+    mode: str = "env",
+    poll_interval: float = DEFAULT_POLL_INTERVAL,
+    timeout: float = DEFAULT_TIMEOUT,
+) -> list[str]:
+    """Fetch a real MSA for a query sequence, using disk cache when available.
+
+    On first call for a given sequence, queries the ColabFold MMseqs2 API and
+    caches the result. Subsequent calls return the cached MSA immediately.
+
+    Args:
+        sequence:      Query amino acid string (standard 1-letter codes, no gaps).
+        cache_dir:     Directory for caching MSA results. Created if absent.
+        max_msa_depth: Maximum number of sequences to return (query + homologs).
+                       Caps memory usage for very deep MSAs.
+        mode:          ColabFold search mode: 'env' (default) or 'all'.
+        poll_interval: Seconds between API status polls.
+        timeout:       Maximum seconds to wait for the API job to complete.
+
+    Returns:
+        List of aligned strings. sequences[0] is always the query.
+        All sequences have the same length (gaps represented as '-').
+
+    Raises:
+        requests.HTTPError: On API HTTP errors.
+        TimeoutError:       If the job exceeds `timeout` seconds.
+        RuntimeError:       On API-reported errors.
+    """
+    cache_dir = Path(cache_dir)
+    sequence = sequence.upper().strip()
+
+    # Cache hit
+    cached = _load_cache(cache_dir, sequence)
+    if cached is not None:
+        logger.debug("MSA cache hit for sequence (len=%d)", len(sequence))
+        return cached[:max_msa_depth]
+
+    # Cache miss — call API
+    logger.info("Fetching MSA for sequence (len=%d) from ColabFold…", len(sequence))
+    print(f"  Fetching MSA from ColabFold (L={len(sequence)})…", flush=True)
+
+    job_id = _submit_job(sequence, mode=mode)
+    logger.debug("Submitted job %s", job_id)
+
+    _poll_job(job_id, timeout=timeout, poll_interval=poll_interval)
+
+    tar_bytes = _download_result(job_id)
+    a3m_text = _extract_a3m_from_tar(tar_bytes)
+    sequences = _parse_a3m(a3m_text)
+
+    if not sequences:
+        logger.warning("Empty MSA returned for sequence (len=%d); using query only.", len(sequence))
+        sequences = [sequence]
+
+    # Ensure query is first (API always puts it first, but be defensive)
+    query_clean = sequence.replace("-", "")
+    if sequences[0].replace("-", "") != query_clean:
+        sequences = [sequence] + [s for s in sequences if s != sequence]
+
+    _save_cache(cache_dir, sequence, sequences)
+    logger.info("  Cached %d sequences (depth capped at %d)", len(sequences), max_msa_depth)
+    print(f"  Done — {len(sequences)} homologs found, cached to {cache_dir}/", flush=True)
+
+    return sequences[:max_msa_depth]
+
+
+def prefetch_msas(
+    sequences: list[str],
+    cache_dir: str | Path = "msa_cache",
+    max_msa_depth: int = DEFAULT_MAX_MSA_DEPTH,
+    mode: str = "env",
+    delay_between: float = 1.0,
+    skip_cached: bool = True,
+) -> dict[str, list[str]]:
+    """Pre-fetch and cache MSAs for a list of sequences.
+
+    Intended to be run once before training — populates the cache so the
+    training loop never needs to call the API.
+
+    Args:
+        sequences:      List of query amino acid strings.
+        cache_dir:      Directory for caching results.
+        max_msa_depth:  Maximum sequences per MSA.
+        mode:           ColabFold search mode.
+        delay_between:  Seconds to sleep between API submissions (rate limiting).
+        skip_cached:    If True, skip sequences already in the cache.
+
+    Returns:
+        Dict mapping each sequence to its list of aligned MSA sequences.
+    """
+    cache_dir = Path(cache_dir)
+    results: dict[str, list[str]] = {}
+    total = len(sequences)
+
+    for i, seq in enumerate(sequences):
+        seq = seq.upper().strip()
+        print(f"[{i+1}/{total}] sequence (L={len(seq)})", flush=True)
+
+        if skip_cached and _load_cache(cache_dir, seq) is not None:
+            print(f"  → cache hit, skipping", flush=True)
+            results[seq] = _load_cache(cache_dir, seq)[:max_msa_depth]  # type: ignore[index]
+            continue
+
+        try:
+            msa = fetch_msa(seq, cache_dir=cache_dir,
+                            max_msa_depth=max_msa_depth, mode=mode)
+            results[seq] = msa
+        except Exception as exc:
+            logger.error("Failed to fetch MSA for seq %d: %s", i, exc)
+            print(f"  ERROR: {exc} — falling back to query only", flush=True)
+            results[seq] = [seq]
+
+        if i < total - 1:
+            time.sleep(delay_between)
+
+    print(f"\nPre-fetch complete. {len(results)}/{total} sequences cached in {cache_dir}/")
+    return results
+
+
+def load_cached_msa(
+    sequence: str,
+    cache_dir: str | Path = "msa_cache",
+    max_msa_depth: int = DEFAULT_MAX_MSA_DEPTH,
+    fallback_pseudo: bool = True,
+    n_pseudo: int = 8,
+) -> list[str]:
+    """Load a cached MSA, falling back to pseudo-MSA if not cached.
+
+    Use this in training loops to safely retrieve MSAs without blocking
+    on an API call.
+
+    Args:
+        sequence:       Query amino acid string.
+        cache_dir:      Cache directory to check.
+        max_msa_depth:  Cap on returned sequences.
+        fallback_pseudo: If True and no cache entry exists, generate a
+                         pseudo-MSA rather than raising an error.
+        n_pseudo:       Depth of fallback pseudo-MSA.
+
+    Returns:
+        List of aligned sequences, query first.
+    """
+    cached = _load_cache(Path(cache_dir), sequence.upper().strip())
+    if cached is not None:
+        return cached[:max_msa_depth]
+
+    if fallback_pseudo:
+        from src.data.msa_encoder import generate_pseudo_msa
+        logger.warning(
+            "No cached MSA for sequence (L=%d) — falling back to pseudo-MSA.", len(sequence)
+        )
+        return generate_pseudo_msa(sequence, n_sequences=n_pseudo)
+
+    raise FileNotFoundError(
+        f"No cached MSA found for sequence (L={len(sequence)}) in {cache_dir}. "
+        "Run prefetch_msas() first, or set fallback_pseudo=True."
+    )

--- a/tests/data/test_msa_fetcher.py
+++ b/tests/data/test_msa_fetcher.py
@@ -1,0 +1,253 @@
+"""Tests for src/data/msa_fetcher.py — A3M parsing, caching, and API client."""
+
+import io
+import json
+import tarfile
+import hashlib
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+from src.data.msa_fetcher import (
+    _parse_a3m,
+    _extract_a3m_from_tar,
+    _cache_key,
+    _cache_path,
+    _load_cache,
+    _save_cache,
+    fetch_msa,
+    load_cached_msa,
+    prefetch_msas,
+)
+
+
+# ---------------------------------------------------------------------------
+# A3M parsing
+# ---------------------------------------------------------------------------
+
+SAMPLE_A3M = """\
+>query
+ACDEFGHIK
+>homolog1
+ACDE--HIK
+>homolog2
+ACDEFGhHIK
+>homolog3
+A-DEFGHiIK
+"""
+
+
+def test_parse_a3m_returns_query_first():
+    seqs = _parse_a3m(SAMPLE_A3M)
+    assert seqs[0] == "ACDEFGHIK"
+
+
+def test_parse_a3m_strips_lowercase():
+    """Lowercase insertion characters must be removed from all sequences."""
+    seqs = _parse_a3m(SAMPLE_A3M)
+    for seq in seqs:
+        assert seq == seq.upper() or "-" in seq, \
+            f"Lowercase not stripped: {seq!r}"
+    # homolog2: ACDEFGhHIK → ACDEFGHIK (h removed)
+    assert "h" not in seqs[2]
+    # homolog3: A-DEFGHiIK → A-DEFGHIK (i removed)
+    assert "i" not in seqs[3]
+
+
+def test_parse_a3m_preserves_gaps():
+    """Gap characters '-' must be preserved (they encode alignment columns)."""
+    seqs = _parse_a3m(SAMPLE_A3M)
+    assert "-" in seqs[1]  # homolog1 has gaps
+    assert "-" in seqs[3]  # homolog3 has gap
+
+
+def test_parse_a3m_query_length_matches():
+    """All sequences after stripping insertions must have the same length as query."""
+    seqs = _parse_a3m(SAMPLE_A3M)
+    query_len = len(seqs[0])
+    for seq in seqs:
+        assert len(seq) == query_len, \
+            f"Sequence length {len(seq)} != query length {query_len}: {seq!r}"
+
+
+def test_parse_a3m_empty_returns_empty():
+    assert _parse_a3m("") == []
+
+
+def test_parse_a3m_single_sequence():
+    a3m = ">query\nACDEF\n"
+    seqs = _parse_a3m(a3m)
+    assert seqs == ["ACDEF"]
+
+
+# ---------------------------------------------------------------------------
+# tar.gz extraction
+# ---------------------------------------------------------------------------
+
+def _make_tar(files: dict[str, str]) -> bytes:
+    """Create an in-memory tar.gz with given {filename: content} mapping."""
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w:gz") as tar:
+        for name, content in files.items():
+            encoded = content.encode("utf-8")
+            info = tarfile.TarInfo(name=name)
+            info.size = len(encoded)
+            tar.addfile(info, io.BytesIO(encoded))
+    return buf.getvalue()
+
+
+def test_extract_a3m_prefers_uniref():
+    """When both uniref.a3m and bfd.a3m exist, prefer uniref.a3m."""
+    tar_bytes = _make_tar({
+        "job123/bfd.a3m": ">query\nACDEF\n",
+        "job123/uniref.a3m": ">query\nMKTAY\n",
+    })
+    content = _extract_a3m_from_tar(tar_bytes)
+    assert "MKTAY" in content
+
+
+def test_extract_a3m_fallback_to_first():
+    """If no uniref.a3m, return the first .a3m found."""
+    tar_bytes = _make_tar({"job123/bfd.a3m": ">query\nACDEF\n"})
+    content = _extract_a3m_from_tar(tar_bytes)
+    assert "ACDEF" in content
+
+
+def test_extract_a3m_raises_if_no_a3m():
+    tar_bytes = _make_tar({"job123/result.txt": "nothing here"})
+    with pytest.raises(ValueError, match="No .a3m file"):
+        _extract_a3m_from_tar(tar_bytes)
+
+
+# ---------------------------------------------------------------------------
+# Cache helpers
+# ---------------------------------------------------------------------------
+
+def test_cache_key_is_md5_of_uppercase():
+    seq = "acdef"
+    expected = hashlib.md5("ACDEF".encode()).hexdigest()
+    assert _cache_key(seq) == expected
+
+
+def test_cache_key_case_insensitive():
+    assert _cache_key("ACDEF") == _cache_key("acdef")
+
+
+def test_save_and_load_cache(tmp_path):
+    seq = "ACDEFGHIK"
+    seqs = ["ACDEFGHIK", "ACDE--HIK", "A-DEFGHIK"]
+    _save_cache(tmp_path, seq, seqs)
+    loaded = _load_cache(tmp_path, seq)
+    assert loaded == seqs
+
+
+def test_load_cache_returns_none_if_missing(tmp_path):
+    assert _load_cache(tmp_path, "ACDEFGHIK") is None
+
+
+def test_save_cache_creates_dir(tmp_path):
+    subdir = tmp_path / "nested" / "cache"
+    _save_cache(subdir, "ACDEF", ["ACDEF"])
+    assert _cache_path(subdir, "ACDEF").exists()
+
+
+def test_load_cache_handles_corrupt_file(tmp_path):
+    seq = "ACDEFGHIK"
+    p = _cache_path(tmp_path, seq)
+    p.write_text("not valid json", encoding="utf-8")
+    assert _load_cache(tmp_path, seq) is None
+
+
+# ---------------------------------------------------------------------------
+# fetch_msa (API mocked)
+# ---------------------------------------------------------------------------
+
+def _mock_tar_response(sequences: list[str]) -> bytes:
+    a3m = "\n".join(
+        f">seq{i}\n{seq}" for i, seq in enumerate(sequences)
+    )
+    return _make_tar({"job/uniref.a3m": a3m})
+
+
+def test_fetch_msa_returns_cached_on_second_call(tmp_path):
+    """Second call returns cached result without hitting the API."""
+    seq = "ACDEFGHIK"
+    real_seqs = ["ACDEFGHIK", "ACDE--HIK"]
+    _save_cache(tmp_path, seq, real_seqs)
+
+    with patch("src.data.msa_fetcher.requests.post") as mock_post:
+        result = fetch_msa(seq, cache_dir=tmp_path)
+        mock_post.assert_not_called()
+
+    assert result == real_seqs
+
+
+def test_fetch_msa_calls_api_on_cache_miss(tmp_path):
+    """On cache miss, the API is called and result is cached."""
+    seq = "ACDEFGHIK"
+    homologs = ["ACDEFGHIK", "ACDE--HIK", "A-DEFGHIK"]
+
+    mock_submit = MagicMock()
+    mock_submit.return_value.json.return_value = {"id": "job123"}
+    mock_submit.return_value.raise_for_status = MagicMock()
+
+    mock_poll = MagicMock()
+    mock_poll.return_value.json.return_value = {"status": "COMPLETE"}
+    mock_poll.return_value.raise_for_status = MagicMock()
+
+    mock_download = MagicMock()
+    mock_download.return_value.content = _mock_tar_response(homologs)
+    mock_download.return_value.raise_for_status = MagicMock()
+
+    def side_effect(url, **kwargs):
+        if "ticket/msa" in url:
+            return mock_submit.return_value
+        if "ticket/job123" in url:
+            return mock_poll.return_value
+        if "result/download" in url:
+            return mock_download.return_value
+        raise ValueError(f"Unexpected URL: {url}")
+
+    with patch("src.data.msa_fetcher.requests.post", side_effect=lambda url, **kw: mock_submit.return_value), \
+         patch("src.data.msa_fetcher.requests.get", side_effect=side_effect):
+        result = fetch_msa(seq, cache_dir=tmp_path)
+
+    assert result[0] == homologs[0]
+    # Verify it was cached
+    assert _load_cache(tmp_path, seq) is not None
+
+
+def test_fetch_msa_respects_max_depth(tmp_path):
+    """max_msa_depth caps the number of returned sequences."""
+    seq = "ACDEFGHIK"
+    many_seqs = [seq] + [f"A{'C'*i}FGHIK"[:9] for i in range(20)]
+    _save_cache(tmp_path, seq, many_seqs)
+
+    result = fetch_msa(seq, cache_dir=tmp_path, max_msa_depth=5)
+    assert len(result) <= 5
+
+
+# ---------------------------------------------------------------------------
+# load_cached_msa
+# ---------------------------------------------------------------------------
+
+def test_load_cached_msa_returns_cache(tmp_path):
+    seq = "ACDEFGHIK"
+    seqs = ["ACDEFGHIK", "ACDE--HIK"]
+    _save_cache(tmp_path, seq, seqs)
+    result = load_cached_msa(seq, cache_dir=tmp_path)
+    assert result == seqs
+
+
+def test_load_cached_msa_fallback_to_pseudo(tmp_path):
+    """When cache is empty and fallback_pseudo=True, returns pseudo-MSA."""
+    seq = "ACDEFGHIK"
+    result = load_cached_msa(seq, cache_dir=tmp_path, fallback_pseudo=True, n_pseudo=4)
+    assert len(result) == 5  # query + 4 pseudo
+    assert result[0] == seq
+
+
+def test_load_cached_msa_raises_without_fallback(tmp_path):
+    with pytest.raises(FileNotFoundError):
+        load_cached_msa("ACDEFGHIK", cache_dir=tmp_path, fallback_pseudo=False)


### PR DESCRIPTION
## Summary

- **`src/data/msa_fetcher.py`** — ColabFold MMseqs2 API client with MD5-keyed JSON disk cache. Async flow: submit → poll → download → parse A3M. Public API: `fetch_msa()`, `prefetch_msas()`, `load_cached_msa()` (with pseudo-MSA fallback so training never blocks on the network).
- **`scripts/prefetch_msas.py`** — CLI to bulk pre-cache MSAs before training. Accepts `--pdb-ids`, `--fasta`, or `--sequence-file`; shows cache hit/miss progress.
- **`scripts/train_end_to_end.py`** — added `--msa-cache` and `--max-msa-depth` args; `MSAStructureDataset` now loads real MSAs from disk cache when available, falls back to pseudo-MSA otherwise.
- **`tests/data/test_msa_fetcher.py`** — 21 unit tests covering A3M parsing (lowercase stripping, gap preservation, length invariant), tar.gz extraction (uniref preference, fallback, missing-file error), cache round-trips (save/load, missing, corrupt), and full API flow mocked with `unittest.mock`.

## Test plan

- [ ] `pytest tests/data/test_msa_fetcher.py` — 21 tests pass, no network calls made
- [ ] `pytest` (full suite) — 131 tests pass, no regressions
- [ ] On Colab: `python scripts/prefetch_msas.py --pdb-ids 1UBQ --cache-dir msa_cache` pre-fetches one protein
- [ ] On Colab: `python scripts/train_end_to_end.py --pdb-ids 1UBQ --msa-cache msa_cache` trains with real MSA

🤖 Generated with [Claude Code](https://claude.com/claude-code)