### PR TITLE
fix(data): drop misaligned homologs from parsed A3M files

### DIFF
--- a/src/data/msa_fetcher.py
+++ b/src/data/msa_fetcher.py
@@ -66,7 +66,7 @@ def _parse_a3m(a3m_text: str) -> list[str]:
     Returns:
         List of aligned strings, query first. Empty sequences are skipped.
     """
-    sequences: list[str] = []
+    raw: list[str] = []
     current: list[str] = []
 
     for line in a3m_text.splitlines():
@@ -76,20 +76,32 @@ def _parse_a3m(a3m_text: str) -> list[str]:
         if line.startswith(">"):
             if current:
                 seq = "".join(current)
-                # Remove lowercase insertion characters
                 seq = "".join(ch for ch in seq if not ch.islower())
                 if seq:
-                    sequences.append(seq)
+                    raw.append(seq)
             current = []
         else:
             current.append(line)
 
-    # Flush last entry
     if current:
         seq = "".join(current)
         seq = "".join(ch for ch in seq if not ch.islower())
         if seq:
-            sequences.append(seq)
+            raw.append(seq)
+
+    if not raw:
+        return raw
+
+    # Discard homologs whose aligned length doesn't match the query.
+    # This handles malformed ColabFold entries where uppercase+gap column
+    # counts differ from the query row.
+    query_len = len(raw[0])
+    sequences = [s for s in raw if len(s) == query_len]
+    if len(sequences) < len(raw):
+        logger.warning(
+            "_parse_a3m: dropped %d/%d sequences with length != %d",
+            len(raw) - len(sequences), len(raw), query_len,
+        )
 
     return sequences
 


### PR DESCRIPTION
## Summary

- Real ColabFold A3M responses occasionally include homolog rows whose uppercase+gap column count differs from the query (e.g. 46 vs 47 columns after stripping lowercase insertions)
- This caused `MSAEncoder.encode()` to raise `ValueError: All sequences must be the same length`
- Fix: after parsing, filter out any row whose length != query length and log a warning

## Test plan

- [ ] `pytest tests/data/test_msa_fetcher.py` — 21 tests pass
- [ ] `pytest` — 131 tests pass, no regressions
- [ ] Re-run `train_end_to_end.py` with `--msa-cache` — no more ValueError

**Note:** If you already have cached MSAs with bad entries, delete the `msa_cache/` directory and re-run `prefetch_msas.py` so the corrected parser rebuilds clean cache files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)