### PR TITLE
fix(training): guard num-workers=0 crash in ThreadPoolExecutor

### DIFF
--- a/scripts/train_end_to_end.py
+++ b/scripts/train_end_to_end.py
@@ -518,7 +518,7 @@ def train(args: argparse.Namespace) -> None:
         train_ds, val_ds = build_cached_dataset(
             cache_dir=args.dataset_cache,
             n_pseudo=args.n_pseudo,
-            n_workers=args.num_workers,
+            n_workers=max(1, args.num_workers),
             seed=args.seed,
             n_structures=args.n_structures,
             min_len=args.min_len,


### PR DESCRIPTION
## Summary

- `--num-workers` defaults to 0 (for DataLoader), but `ThreadPoolExecutor` requires `max_workers >= 1`
- Fix: pass `max(1, args.num_workers)` to `build_cached_dataset` so download workers always get at least 1 thread

## Test plan
- [ ] `pytest` — 131 tests pass
- [ ] `train_end_to_end.py --dataset-cache ... --n-structures 300` no longer crashes on startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)