### PR TITLE
feat(data): wire real MSA cache into LargeStructureDataset

### DIFF
--- a/scripts/train_end_to_end.py
+++ b/scripts/train_end_to_end.py
@@ -323,6 +323,8 @@ def build_cached_dataset(
     max_len:      int   = 300,
     val_fraction: float = 0.1,
     n_structures: int   = 300,
+    msa_cache_dir: Optional[str] = None,
+    max_msa_depth: int   = 512,
 ):
     """Build train/val datasets from the curated structure cache.
 
@@ -355,6 +357,8 @@ def build_cached_dataset(
         max_len=max_len,
         val_fraction=val_fraction,
         n_structures=n_structures,
+        msa_cache_dir=msa_cache_dir,
+        max_msa_depth=max_msa_depth,
     )
     print(f"  Train: {len(train_ds):,} | Val: {len(val_ds):,}")
     return train_ds, val_ds
@@ -525,6 +529,8 @@ def train(args: argparse.Namespace) -> None:
             n_structures=args.n_structures,
             min_len=args.min_len,
             max_len=args.max_len,
+            msa_cache_dir=args.msa_cache,
+            max_msa_depth=args.max_msa_depth,
         )
     elif args.pdb_ids:
         pdb_list = [p.strip().upper() for p in args.pdb_ids.split(",")]

--- a/src/data/structure_dataset.py
+++ b/src/data/structure_dataset.py
@@ -464,17 +464,21 @@ class LargeStructureDataset(Dataset):
         seed:          int   = 42,
         min_len:       int   = 30,
         max_len:       int   = 300,
+        msa_cache_dir: Optional[str | Path] = None,
+        max_msa_depth: int   = 512,
     ) -> None:
         from src.data.protein_dataset import tokenize
         from src.data.msa_encoder import MSAEncoder, generate_pseudo_msa
 
-        self._cache       = cache
-        self._n_pseudo    = n_pseudo
-        self._mut_rate    = mutation_rate
-        self._seed        = seed
-        self._tokenize    = tokenize
-        self._msa_encoder = MSAEncoder()
-        self._gen_pseudo  = generate_pseudo_msa
+        self._cache         = cache
+        self._n_pseudo      = n_pseudo
+        self._mut_rate      = mutation_rate
+        self._seed          = seed
+        self._tokenize      = tokenize
+        self._msa_encoder   = MSAEncoder()
+        self._gen_pseudo    = generate_pseudo_msa
+        self._msa_cache_dir = Path(msa_cache_dir) if msa_cache_dir is not None else None
+        self._max_msa_depth = max_msa_depth
 
         # Eagerly load all structures so __len__ is reliable and we can filter
         self._data: list[tuple[str, object]] = []   # (pdb_id, StructureData)
@@ -501,12 +505,22 @@ class LargeStructureDataset(Dataset):
 
         tokens = self._tokenize(sd.sequence)   # (L,) long
 
-        msa_seqs = self._gen_pseudo(
-            sd.sequence,
-            n_sequences=self._n_pseudo,
-            mutation_rate=self._mut_rate,
-            seed=self._seed + idx,
-        )
+        if self._msa_cache_dir is not None:
+            from src.data.msa_fetcher import load_cached_msa
+            msa_seqs = load_cached_msa(
+                sd.sequence,
+                cache_dir=self._msa_cache_dir,
+                max_msa_depth=self._max_msa_depth,
+                fallback_pseudo=True,
+                n_pseudo=self._n_pseudo,
+            )
+        else:
+            msa_seqs = self._gen_pseudo(
+                sd.sequence,
+                n_sequences=self._n_pseudo,
+                mutation_rate=self._mut_rate,
+                seed=self._seed + idx,
+            )
         msa_feat = self._msa_encoder.encode(msa_seqs)   # MSAFeatures
         msa      = msa_feat.features                     # (N_seq, L, 45)
 
@@ -516,10 +530,12 @@ class LargeStructureDataset(Dataset):
         lengths = [len(sd.sequence) for _, sd in self._data]
         if lengths:
             avg_L = sum(lengths) / len(lengths)
+            msa_cache = str(self._msa_cache_dir) if self._msa_cache_dir is not None else None
             return (
                 f"LargeStructureDataset(n={len(self)}, "
                 f"avg_L={avg_L:.0f}, "
-                f"n_pseudo={self._n_pseudo})"
+                f"n_pseudo={self._n_pseudo}, "
+                f"msa_cache={msa_cache!r})"
             )
         return f"LargeStructureDataset(n=0)"
 
@@ -539,6 +555,8 @@ def build_large_dataset(
     min_len:       int   = 30,
     max_len:       int   = 300,
     seed:          int   = 42,
+    msa_cache_dir: Optional[str | Path] = None,
+    max_msa_depth: int   = 512,
 ) -> tuple["LargeStructureDataset", "LargeStructureDataset"]:
     """Download, cache, and split structures into train / val datasets.
 
@@ -582,11 +600,17 @@ def build_large_dataset(
         seed=seed,
         min_len=min_len,
         max_len=max_len,
+        msa_cache_dir=msa_cache_dir,
+        max_msa_depth=max_msa_depth,
     )
     train_ds = LargeStructureDataset(train_ids, **ds_kwargs)
     val_ds   = LargeStructureDataset(val_ids,   **ds_kwargs)
 
     print(f"Dataset split — train: {len(train_ds)}, val: {len(val_ds)}")
+    if msa_cache_dir is not None:
+        print(f"MSA source: real (cache: {msa_cache_dir})")
+    else:
+        print("MSA source: pseudo-MSA (no cache provided)")
     return train_ds, val_ds
 
 


### PR DESCRIPTION
## Summary

- `LargeStructureDataset.__init__` now accepts `msa_cache_dir` and `max_msa_depth` params, stored as instance attributes
- `__getitem__` branches on `msa_cache_dir`: loads real MSAs via `load_cached_msa()` when set, falls back to pseudo-MSA per-sequence gracefully
- `__repr__` now shows `msa_cache=...` so users can confirm real MSAs are active
- `build_large_dataset` and `build_cached_dataset` pass the new params through; prints `MSA source: real (cache: ...)` or `MSA source: pseudo-MSA (no cache provided)` after dataset construction
- `train()` passes `args.msa_cache` and `args.max_msa_depth` to `build_cached_dataset` in the `--dataset-cache` branch

## Test plan

- [x] All 131 existing tests pass (`python -m pytest --tb=short -q`)
- [ ] Manual: run with `--dataset-cache` only → verify "MSA source: pseudo-MSA" printed
- [ ] Manual: run with `--dataset-cache` + `--msa-cache` → verify "MSA source: real" printed and TM-score improves over baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)