### PR TITLE
fix(data): handle variable MSA depth in collate_msa_structure

### DIFF
--- a/scripts/train_end_to_end.py
+++ b/scripts/train_end_to_end.py
@@ -191,15 +191,16 @@ def collate_msa_structure(
     lengths = torch.tensor([t.size(0) for t in tokens_list], dtype=torch.long)
     L_max   = int(lengths.max().item())
     B       = len(tokens_list)
-    N_seq   = msa_list[0].shape[0]
+    N_seq    = max(m.shape[0] for m in msa_list)
     feat_dim = msa_list[0].shape[2]
 
     tokens = pad_sequence(tokens_list, batch_first=True, padding_value=PAD_IDX)
 
     msa = torch.zeros(B, N_seq, L_max, feat_dim)
     for b, m in enumerate(msa_list):
+        n_b = m.shape[0]
         L_b = m.shape[1]
-        msa[b, :, :L_b, :] = m
+        msa[b, :n_b, :L_b, :] = m
 
     coords = torch.zeros(B, L_max, 4, 3, dtype=torch.float32)
     for b, c in enumerate(coords_list):


### PR DESCRIPTION
## Summary

When `--msa-cache` is used with `--dataset-cache`, some structures have real MSAs (depth 512) while others fall back to pseudo-MSA (depth 9). The collate function assumed all items in a batch share the same `N_seq`, causing a RuntimeError when they differ.

Fix: allocate the batch MSA tensor to `max(N_seq)` across the batch and copy each item up to its actual depth. Zero rows are ignored by attention.

## Test plan
- [ ] `pytest` — 131 tests pass
- [ ] `train_end_to_end.py --dataset-cache ... --msa-cache ...` runs past epoch 1 without RuntimeError

🤖 Generated with [Claude Code](https://claude.com/claude-code)